### PR TITLE
すでにランチに行ったメンバーの組み合わせは選択できない機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :development do
   gem 'binding_of_caller'
 
   gem 'spring-commands-rspec'
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'jquery-rails'
 gem 'select2-rails'
 gem 'materialize-sass', '~> 1.0.0'
 gem 'material_icons' 
+gem 'gon'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,10 @@ GEM
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gon (6.2.1)
+      actionpack (>= 3.0)
+      multi_json
+      request_store (>= 1.0)
     hashie (3.6.0)
     hpricot (0.8.6)
     html2slim (0.2.0)
@@ -193,6 +197,8 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     regexp_parser (1.6.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -291,6 +297,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   factory_bot_rails (~> 4.11)
+  gon
   html2slim
   jbuilder (~> 2.5)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,9 @@ GEM
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
+    bullet (6.0.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.0.1)
     capybara (3.28.0)
       addressable
@@ -268,6 +271,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    uniform_notifier (1.12.1)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -292,6 +296,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
+  bullet
   byebug
   capybara (>= 2.15)
   devise

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -26,7 +26,7 @@ document.addEventListener('turbolinks:load', function() {
   function noDisplayMember(members){
     for(const member of members) {
       member.classList.remove('unselectable-row');
-      if (hasSameProjects(member) || isGone(member))
+      if (hasSameProjects(member) || isUsedBenefitWithSelectedMembers(member))
         member.classList.add('unselectable-row');
     }
   }
@@ -41,7 +41,7 @@ document.addEventListener('turbolinks:load', function() {
     return existsIntersection(memberProjects, selectedProjects);
   }
 
-  function isGone(member) {
+  function isUsedBenefitWithSelectedMembers(member) {
     const memberName = member.children[0].textContent;
     const selectedNames = Array
       .from(document.querySelectorAll('.selected-row'))

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -26,7 +26,7 @@ document.addEventListener('turbolinks:load', function() {
   function noDisplayMember(members){
     for(const member of members) {
       member.classList.remove('unselectable-row');
-      if ( hasSameProjects(member) || isGone(member))
+      if (hasSameProjects(member) || isGone(member))
         member.classList.add('unselectable-row');
     }
   }

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -34,9 +34,22 @@ document.addEventListener('turbolinks:load', function() {
     for(const member of members) {
       member.classList.remove('unselectable-row');
       const arr = member.children[1].textContent.split(',');
-      if (intersection(arr, selected_projects).size !== 0)
+      if (intersection(arr, selected_projects).size !== 0 || isGone(member))
         member.classList.add('unselectable-row');
     }
+  }
+
+  function isGone(member) {
+    const member_name = member.children[0].textContent;
+    const selectedRows = document.querySelectorAll('.selected-row');
+    const selected_names = Array.from(selectedRows).map(row => row.children[0].textContent);
+    const lunches_members = gon.lunches_members;
+    for(const lunch_members of lunches_members) {
+      const names = lunch_members.map(e => e["real_name"]);
+      if (names.some(name => name === member_name) && intersection(names, selected_names).size !== 0)
+        return true;
+    };
+    return false;
   }
 
   function intersection(arr1, arr2){

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -46,8 +46,8 @@ document.addEventListener('turbolinks:load', function() {
     const selectedNames = Array
       .from(document.querySelectorAll('.selected-row'))
       .map(row => row.children[0].textContent);
-    for(const lunchMembers of gon.lunches_members) {
-      const names = lunchMembers.map(e => e["real_name"]);
+    for(const trio of gon.lunch_trios) {
+      const names = trio.map(e => e["real_name"]);
       if (names.some(name => name === memberName) && existsIntersection(names, selectedNames))
         return true;
     };

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -24,38 +24,41 @@ document.addEventListener('turbolinks:load', function() {
 
   // どのメンバーを表示しないか
   function noDisplayMember(members){
-    const selectedRows = document.querySelectorAll('.selected-row');
-    const selected_projects = Array
-      .from(selectedRows)
-      .map(row => row.children[1].textContent.split(','))
-      .flat()
-      .filter(n => n !== '');
-
     for(const member of members) {
       member.classList.remove('unselectable-row');
-      const arr = member.children[1].textContent.split(',');
-      if (intersection(arr, selected_projects).size !== 0 || isGone(member))
+      if ( hasSameProjects(member) || isGone(member))
         member.classList.add('unselectable-row');
     }
   }
 
+  function hasSameProjects(member) {
+    const selectedProjects = Array
+      .from(document.querySelectorAll('.selected-row'))
+      .map(row => row.children[1].textContent.split(','))
+      .flat()
+      .filter(n => n !== '');
+    const memberProjects = member.children[1].textContent.split(',');
+    return existsIntersection(memberProjects, selectedProjects);
+  }
+
   function isGone(member) {
-    const member_name = member.children[0].textContent;
-    const selectedRows = document.querySelectorAll('.selected-row');
-    const selected_names = Array.from(selectedRows).map(row => row.children[0].textContent);
-    const lunches_members = gon.lunches_members;
-    for(const lunch_members of lunches_members) {
-      const names = lunch_members.map(e => e["real_name"]);
-      if (names.some(name => name === member_name) && intersection(names, selected_names).size !== 0)
+    const memberName = member.children[0].textContent;
+    const selectedNames = Array
+      .from(document.querySelectorAll('.selected-row'))
+      .map(row => row.children[0].textContent);
+    for(const lunchMembers of gon.lunches_members) {
+      const names = lunchMembers.map(e => e["real_name"]);
+      if (names.some(name => name === memberName) && existsIntersection(names, selectedNames))
         return true;
     };
     return false;
   }
 
-  function intersection(arr1, arr2){
+  function existsIntersection(arr1, arr2){
     const set1 = new Set(arr1);
     const set2 = new Set(arr2);
-    return new Set([...set1].filter(e => (set2.has(e))));
+    const intersection =  new Set([...set1].filter(e => (set2.has(e))));
+    return intersection.size !== 0;
   }
 
   function findEmptyForm(forms) {

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -2,7 +2,7 @@ class LunchesController < ApplicationController
   def new
     @members = Member.includes(:projects)
     @lunch = Lunch.new
-    gon.lunches_members = Lunch.includes(:members).map(&:members)
+    gon.lunch_trios = Lunch.includes(:members).map(&:members)
   end
 
   def create

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -2,6 +2,7 @@ class LunchesController < ApplicationController
   def new
     @members = Member.includes(:projects)
     @lunch = Lunch.new
+    gon.lunches_members = Lunch.all.map(&:members)
   end
 
   def create

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -2,7 +2,7 @@ class LunchesController < ApplicationController
   def new
     @members = Member.includes(:projects)
     @lunch = Lunch.new
-    gon.lunches_members = Lunch.all.map(&:members)
+    gon.lunches_members = Lunch.includes(:members).map(&:members)
   end
 
   def create

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,7 +6,9 @@ html
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = include_gon
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+
   body
     = render 'layouts/navbar'
     .container

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,10 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.console = true
+    Bullet.add_footer = true
+  end
 end

--- a/spec/factories/lunches.rb
+++ b/spec/factories/lunches.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :lunch do
-    date { "2019-08-13" }
+    date { Date.today }
   end
 end

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -1,26 +1,44 @@
 require 'rails_helper'
 
 describe '3人組を探す機能' do
+  let!(:project) { create(:project) }
+  let!(:member1) { create(:member, real_name: '鈴木一郎', projects: [project]) }
+  let!(:member2) { create(:member, real_name: '鈴木二郎') }
+  let!(:member3) { create(:member, real_name: '鈴木三郎') }
+
   before do
-    project = create(:project)
     create(:member, projects: [project])
-    create(:member, real_name: '鈴木一郎', projects: [project])
-    create(:member, real_name: '鈴木二郎')
-    create(:member, real_name: '鈴木三郎')
     sign_in create(:user)
     visit root_path
   end
 
-  describe 'メンバー選択' do
+  describe 'メンバーを選択する' do
     it '名前をクリックすると枠に移動するか' do
       find('.member-name', text: '山田太郎').click
       expect(first('.member-form').value).to eq '山田太郎'
       expect(find('#members-list')).to_not have_content('山田太郎')
     end
 
-    it '名前をクリックすると同じプロジェクトのメンバーの表示が消えるか' do
-      find('.member-name', text: '山田太郎').click
-      expect(find('#members-list')).to_not have_content('鈴木一郎')
+    context '同じプロジェクトに所属するメンバー同士の組み合わせの場合' do
+      it 'メンバーの表示が消えて選択できない' do
+        find('.member-name', text: '山田太郎').click
+        expect(find('#members-list')).to_not have_content('鈴木一郎')
+      end
+    end
+
+    context 'すでにランチに行っているメンバー同士の組み合わせの場合' do
+      before do
+        create(:lunch, members: [member1, member2, member3])
+        visit root_path
+      end
+
+      it 'メンバーの表示が消えて選択できない' do
+        expect(find('#members-list')).to have_content('鈴木二郎')
+        expect(find('#members-list')).to have_content('鈴木三郎')
+        find('.member-name', text: '鈴木一郎').click
+        expect(find('#members-list')).to_not have_content('鈴木二郎')
+        expect(find('#members-list')).to_not have_content('鈴木三郎')
+      end
     end
   end
 


### PR DESCRIPTION
Ref: #20 

### 概要
ユーザーが左のメンバーリストから選択すると、
すでにランチに行った組み合わせがあるためにフォームに入力されているメンバーと行くことができないメンバーは、左のリストに表示されないようにした。

下の動画はランチに行ったことを登録することからやっています

[![Image from Gyazo](https://i.gyazo.com/69088bfe1e52a242096a85b33a1334e8.gif)](https://gyazo.com/69088bfe1e52a242096a85b33a1334e8)

### 補足
- 3ヶ月でリセットされる機能についてはこのPRの対象外
- #26 がmasterにmergeされたらこのPRのmerge先をmasterに変更する。
