### PR TITLE
既存のモデルにValidationを設定

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -1,6 +1,6 @@
 class LunchesController < ApplicationController
   def new
-    set_variables
+    set_variables_for_new_lunch_view
     @lunch = Lunch.new
   end
 
@@ -10,14 +10,14 @@ class LunchesController < ApplicationController
     if @lunch.save
       redirect_to root_url, notice: 'Lunch was successfully created.'
     else
-      set_variables
+      set_variables_for_new_lunch_view
       render :new
     end
   end
 
   private
 
-  def set_variables
+  def set_variables_for_new_lunch_view
     @members = Member.includes(:projects)
     gon.lunch_trios = Lunch.includes(:members).map(&:members)
     gon.login_member = Member.find_by(email: current_user.email)

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -1,9 +1,7 @@
 class LunchesController < ApplicationController
   def new
-    @members = Member.includes(:projects)
+    set_variables
     @lunch = Lunch.new
-    gon.lunch_trios = Lunch.includes(:members).map(&:members)
-    gon.login_member = Member.find_by(email: current_user.email)
   end
 
   def create
@@ -12,7 +10,16 @@ class LunchesController < ApplicationController
     if @lunch.save
       redirect_to root_url, notice: 'Lunch was successfully created.'
     else
+      set_variables
       render :new
     end
+  end
+
+  private
+
+  def set_variables
+    @members = Member.includes(:projects)
+    gon.lunch_trios = Lunch.includes(:members).map(&:members)
+    gon.login_member = Member.find_by(email: current_user.email)
   end
 end

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -1,10 +1,12 @@
 class Lunch < ApplicationRecord
   has_and_belongs_to_many :members
-  validate :must_have_three_members
+  validate :must_have_max_members
 
-  def must_have_three_members
-    unless members.size == 3
-      errors.add(:members, '3人のメンバーを入力してください')
+  MEMBERS_NUMBER = 3
+
+  def must_have_max_members
+    unless members.size == MEMBERS_NUMBER
+      errors.add(:members, "#{MEMBERS_NUMBER}人のメンバーを入力してください")
     end
   end
 end

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -1,12 +1,12 @@
 class Lunch < ApplicationRecord
   has_and_belongs_to_many :members
-  validate :must_have_max_members
+  validate :must_have_benefits_available_count_members
 
-  MEMBERS_NUMBER = 3
+  BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
 
-  def must_have_max_members
-    unless members.size == MEMBERS_NUMBER
-      errors.add(:members, "#{MEMBERS_NUMBER}人のメンバーを入力してください")
-    end
+  def must_have_benefits_available_count_members
+    return if members.size == BENEFITS_AVAILABLE_MEMBERS_COUNT
+
+    errors.add(:members, "#{BENEFITS_AVAILABLE_MEMBERS_COUNT}人のメンバーを入力してください")
   end
 end

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -1,3 +1,10 @@
 class Lunch < ApplicationRecord
   has_and_belongs_to_many :members
+  validate :must_have_three_members
+
+  def must_have_three_members
+    unless members.size == 3
+      errors.add(:members, '3人のメンバーを入力してください')
+    end
+  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -3,4 +3,6 @@ class Member < ApplicationRecord
   has_many :projects, through: :assignments
   has_and_belongs_to_many :lunches
   validates :email, uniqueness: true, allow_nil: true
+  validates :hundle_name, presence: true
+  validates :real_name, presence: true
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,6 @@
 class Project < ApplicationRecord
   has_many :assignment
   has_many :members, through: :assignment
+
+  validates :name, presence: true
 end

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -12,7 +12,12 @@ h3 ランチに行くメンバーを探す
               td.member-name = member.real_name
               td.member-project = member.projects.pluck(:name).join(',')
   .col.s6
-    = form_with model: @lunch do |f|
+    = form_with model: @lunch, local: true do |f|
+      - if @lunch.errors.any?
+        #error_explanation.red-text
+          ul
+            - @lunch.errors.messages.values.flatten.each do |message|
+              li = message
       .input-field
         = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'member-form center-align white black-text' 
       .input-field 

--- a/app/views/members/_form.html.slim
+++ b/app/views/members/_form.html.slim
@@ -1,7 +1,6 @@
 = form_for @member do |f|
   - if @member.errors.any?
-    #error_explanation
-      h2 = "#{pluralize(@member.errors.count, "error")} prohibited this member from being saved:"
+    #error_explanation.red-text
       ul
         - @member.errors.full_messages.each do |message|
           li = message

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -1,7 +1,6 @@
 = form_for @project do |f|
   - if @project.errors.any?
-    #error_explanation
-      h2 = "#{pluralize(@project.errors.count, "error")} prohibited this project from being saved:"
+    #error_explanation.red-text
       ul
         - @project.errors.full_messages.each do |message|
           li = message

--- a/spec/model/lunch_spec.rb
+++ b/spec/model/lunch_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Lunch do
-  it '3人のメンバーが使われてないと有効でないこと' do
+  it '3人のメンバーが選ばれていないと有効ではないこと' do
     member1 = create(:member, real_name: '鈴木一郎')
     member2 = create(:member, real_name: '鈴木二郎')
     lunch = build(:lunch, members: [member1, member2])

--- a/spec/model/lunch_spec.rb
+++ b/spec/model/lunch_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe Lunch do
+  it '3人のメンバーが使われてないと有効でないこと' do
+    member1 = create(:member, real_name: '鈴木一郎')
+    member2 = create(:member, real_name: '鈴木二郎')
+    lunch = build(:lunch, members: [member1, member2])
+    expect(lunch).to_not be_valid
+  end
+end

--- a/spec/model/member_spec.rb
+++ b/spec/model/member_spec.rb
@@ -1,12 +1,18 @@
 require 'rails_helper'
 
 describe Member do
-  before do
+  it 'メールアドレスの重複は有効ではないか' do
     create(:member, email: 'sample@esm.co.jp')
+    member = Member.new(hundle_name: 'yama', real_name: '山本太郎', email: 'sample@esm.co.jp')
   end
 
-  it 'メールアドレスの重複は有効ではないか' do
-    member = Member.new(hundle_name: 'yama', real_name: '山本太郎', email: 'sample@esm.co.jp')
+  it 'ハンドルネームがないと有効でないこと' do
+    member = Member.new(hundle_name: '', real_name: '山田太郎')
+    expect(member).to_not be_valid
+  end
+
+  it '氏名がないと有効でないこと' do
+    member = Member.new(hundle_name: 'yama', real_name: '')
     expect(member).to_not be_valid
   end
 end

--- a/spec/model/member_spec.rb
+++ b/spec/model/member_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 
 describe Member do
-  it 'メールアドレスの重複は有効ではないか' do
+  it 'メールアドレスの重複は有効ではないこと' do
     create(:member, email: 'sample@esm.co.jp')
     member = Member.new(hundle_name: 'yama', real_name: '山本太郎', email: 'sample@esm.co.jp')
     expect(member).to_not be_valid
   end
 
-  it 'ハンドルネームがないと有効でないこと' do
+  it 'ハンドルネームがないと有効ではないこと' do
     member = Member.new(hundle_name: '', real_name: '山田太郎')
     expect(member).to_not be_valid
   end
 
-  it '氏名がないと有効でないこと' do
+  it '氏名がないと有効ではないこと' do
     member = Member.new(hundle_name: 'yama', real_name: '')
     expect(member).to_not be_valid
   end

--- a/spec/model/member_spec.rb
+++ b/spec/model/member_spec.rb
@@ -4,6 +4,7 @@ describe Member do
   it 'メールアドレスの重複は有効ではないか' do
     create(:member, email: 'sample@esm.co.jp')
     member = Member.new(hundle_name: 'yama', real_name: '山本太郎', email: 'sample@esm.co.jp')
+    expect(member).to_not be_valid
   end
 
   it 'ハンドルネームがないと有効でないこと' do

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe Project do
+  it '名前がないと有効でないこと' do
+    project = Project.new(name: '')
+    expect(project).to_not be_valid
+  end
+end

--- a/spec/model/project_spec.rb
+++ b/spec/model/project_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Project do
-  it '名前がないと有効でないこと' do
+  it '名前がないと有効ではないこと' do
     project = Project.new(name: '')
     expect(project).to_not be_valid
   end

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -43,15 +43,23 @@ describe '3人組を探す機能' do
   end
 
   describe 'ランチに行ったことの登録機能' do
-    before do
-      find('.member-name', text: '鈴木一郎').click
-      find('.member-name', text: '鈴木二郎').click
-      find('.member-name', text: '鈴木三郎').click
+    context '3人を選ぶ場合' do
+      it 'ランチに行ったことが登録できること' do
+        find('.member-name', text: '鈴木一郎').click
+        find('.member-name', text: '鈴木二郎').click
+        find('.member-name', text: '鈴木三郎').click
+        find('#submit-btn').click
+        expect(page).to have_content 'Lunch was successfully created.'
+      end
     end
 
-    it 'ランチに行ったことが登録されるか' do
-      find('#submit-btn').click
-      expect(page).to have_content 'Lunch was successfully created.'
+    context '3人未満を選ぶ場合' do
+      it 'ランチに行ったことが登録できないこと' do
+        find('.member-name', text: '鈴木一郎').click
+        find('.member-name', text: '鈴木二郎').click
+        find('#submit-btn').click
+        expect(page).to have_content '3人のメンバーを入力してください'
+      end
     end
   end
 

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -17,13 +17,24 @@ describe 'メンバー管理機能', type: :system do
   end
 
   describe '新規作成機能' do
-    it '新規に追加できるか' do
-      find('#new-btn').click
-      fill_in 'member[hundle_name]', with: 'hanako'
-      fill_in 'member[real_name]', with: '山田花子'
-      find('#submit-btn').click
-      expect(page).to have_content 'hanako'
-      expect(page).to have_content '山田花子'
+    context '名前が入力される場合' do
+      it '新規に追加できること' do
+        find('#new-btn').click
+        fill_in 'member[hundle_name]', with: 'hanako'
+        fill_in 'member[real_name]', with: '山田花子'
+        find('#submit-btn').click
+        expect(page).to have_content 'hanako'
+        expect(page).to have_content '山田花子'
+      end
+    end
+
+    context '名前が入力されない場合' do
+      it '新規に追加できないこと' do
+        find('#new-btn').click
+        find('#submit-btn').click
+        expect(page).to have_content "Hundle name can't be blank"
+        expect(page).to have_content "Real name can't be blank"
+      end
     end
   end
 

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -15,11 +15,21 @@ describe 'プロジェクト管理機能' do
   end
 
   describe '新規作成機能' do
-    it '新規に追加できるか' do
-      find('#new-btn').click
-      fill_in 'project[name]', with: 'プロダクト'
-      find('#submit-btn').click
-      expect(page).to have_content 'プロダクト'
+    context '名前が入力される場合' do
+      it '新規に追加できること' do
+        find('#new-btn').click
+        fill_in 'project[name]', with: 'プロダクト'
+        find('#submit-btn').click
+        expect(page).to have_content 'プロダクト'
+      end
+    end
+
+    context '名前が入力されない場合' do
+      it '新規に追加できないこと' do
+        find('#new-btn').click
+        find('#submit-btn').click
+        expect(page).to have_content "Name can't be blank"
+      end
     end
   end
 


### PR DESCRIPTION
# Issue
close #29 

# 内容
- 名前の無いメンバーは保存できないようにする
- 名前の無いプロジェクトは保存できないようにする
- メンバーが３人でないとランチは保存できないようにする


### 名前の無いメンバーは保存できないようにする
メンバーの名前はその人を識別するのに必要です。メンバーの新規追加や編集で名前のないメンバーが作れてしまっていたため、validationで名前を必須にした。

[![Image from Gyazo](https://i.gyazo.com/c0af7e188affb1376ae4fb9b276b10e3.gif)](https://gyazo.com/c0af7e188affb1376ae4fb9b276b10e3)

### 名前の無いプロジェクトは保存できないようにする
プロジェクトの名前はそのプロジェクトを識別するのに必要です。プロジェクトも同様に名前のないプロジェクトが作れてしまっていたため、validationで名前を必須にした。

[![Image from Gyazo](https://i.gyazo.com/a536f2fe8513ae1f8e2acd3835f03fd6.gif)](https://gyazo.com/a536f2fe8513ae1f8e2acd3835f03fd6)

### メンバーが３人でないとランチは保存できないようにする

現状ではランチ給付金を使うにはメンバーが3人で行くと決まっているが、ランチモデルはメンバーが３人未満でも登録できてしまっていた。それだと3人未満でランチに行ったことになってしまうため、validationでメンバーは3人を必須にした。

[![Image from Gyazo](https://i.gyazo.com/ecb9dc0ffb413f55abc27a1f20a43cc6.gif)](https://gyazo.com/ecb9dc0ffb413f55abc27a1f20a43cc6)

## 補足
メッセージの日本語化は別のPRで対応する。