### PR TITLE
現在のクウォーターのランチ履歴だけを使って組み合わせの判断をする

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -19,7 +19,7 @@ class LunchesController < ApplicationController
 
   def set_variables_for_new_lunch_view
     @members = Member.includes(:projects)
-    gon.lunch_trios = Lunch.includes(:members).map(&:members)
+    gon.lunch_trios = Lunch.in_current_quarter.includes(:members).map(&:members)
     gon.login_member = Member.find_by(email: current_user.email)
   end
 end

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -2,7 +2,21 @@ class Lunch < ApplicationRecord
   has_and_belongs_to_many :members
   validate :must_have_benefits_available_count_members
 
+  scope :in_current_quarter, -> { where(date: current_quarter) }
+
   BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
+  TERM_START_MONTH = 8
+
+  def self.current_quarter
+    today = Date.today
+    current_term_start_year = today.month >= TERM_START_MONTH ? today.year : today.year - 1
+    current_term_start_date = Date.new(current_term_start_year, TERM_START_MONTH)
+    3.step(12, 3)
+      .map { |n| current_term_start_date.next_month(n - 3) ... current_term_start_date.next_month(n) }
+      .detect { |quarter| quarter.cover?(today) }
+  end
+
+  private
 
   def must_have_benefits_available_count_members
     return if members.size == BENEFITS_AVAILABLE_MEMBERS_COUNT

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -5,15 +5,15 @@ class Lunch < ApplicationRecord
   scope :in_current_quarter, -> { where(date: current_quarter) }
 
   BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
-  TERM_START_MONTH = 8
+  DIFF_BETWEEN_JANUARY_AND_TERM_START_MOMTH = 7
 
   def self.current_quarter
-    today = Date.today
-    current_term_start_year = today.month >= TERM_START_MONTH ? today.year : today.year - 1
-    current_term_start_date = Date.new(current_term_start_year, TERM_START_MONTH)
-    3.step(12, 3)
-      .map { |n| current_term_start_date.next_month(n - 3) ... current_term_start_date.next_month(n) }
-      .detect { |quarter| quarter.cover?(today) }
+    beginning_of_current_quarter = Date.today
+      .prev_month(DIFF_BETWEEN_JANUARY_AND_TERM_START_MOMTH)
+      .beginning_of_quarter
+      .next_month(DIFF_BETWEEN_JANUARY_AND_TERM_START_MOMTH)
+    beginning_of_next_quarter = beginning_of_current_quarter.next_month(3)
+    beginning_of_current_quarter ... beginning_of_next_quarter
   end
 
   private

--- a/spec/model/lunch_spec.rb
+++ b/spec/model/lunch_spec.rb
@@ -9,14 +9,25 @@ describe Lunch do
   end
 
   describe 'scope' do
-    it 'in_current_quarter' do
-      member1 = create(:member, real_name: '鈴木一郎')
-      member2 = create(:member, real_name: '鈴木二郎')
-      member3 = create(:member, real_name: '鈴木三郎')
-      create(:lunch, members: [member1, member2, member3])
-      create(:lunch, date: Date.today.next_year, members: [member1, member2, member3])
-      expect(Lunch.count).to eq 2
-      expect(Lunch.in_current_quarter.count).to eq 1
+    describe 'in_current_quarter' do
+      let(:member1) { create(:member, real_name: '鈴木一郎') }
+      let(:member2) { create(:member, real_name: '鈴木二郎') }
+      let(:member3) { create(:member, real_name: '鈴木三郎') }
+
+      it '今日行ったランチは含まれること' do
+        today_lunch = create(:lunch, members: [member1, member2, member3])
+        expect(Lunch.in_current_quarter).to include today_lunch
+      end
+
+      it '3ヶ月前行ったランチは含まれないこと' do
+        three_month_ago_lunch = create(:lunch, date: Date.today.prev_month(3), members: [member1, member2, member3])
+        expect(Lunch.in_current_quarter).to_not include three_month_ago_lunch
+      end
+
+      it '去年行ったランチは含まれないこと' do
+        last_year_lunch = create(:lunch, date: Date.today.last_year, members: [member1, member2, member3])
+        expect(Lunch.in_current_quarter).to_not include last_year_lunch
+      end
     end
   end
 end

--- a/spec/model/lunch_spec.rb
+++ b/spec/model/lunch_spec.rb
@@ -7,4 +7,16 @@ describe Lunch do
     lunch = build(:lunch, members: [member1, member2])
     expect(lunch).to_not be_valid
   end
+
+  describe 'scope' do
+    it 'in_current_quarter' do
+      member1 = create(:member, real_name: '鈴木一郎')
+      member2 = create(:member, real_name: '鈴木二郎')
+      member3 = create(:member, real_name: '鈴木三郎')
+      create(:lunch, members: [member1, member2, member3])
+      create(:lunch, date: Date.today.next_year, members: [member1, member2, member3])
+      expect(Lunch.count).to eq 2
+      expect(Lunch.in_current_quarter.count).to eq 1
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -12,6 +12,14 @@ describe '3人組を探す機能' do
     visit root_path
   end
 
+  describe 'メンバー選択リスト' do
+    it 'メンバーがリストに表示されること' do
+      expect(find('#members-list')).to have_content('鈴木一郎')
+      expect(find('#members-list')).to have_content('鈴木二郎')
+      expect(find('#members-list')).to have_content('鈴木三郎')
+    end
+  end
+
   describe 'メンバーを選択する' do
     it '名前をクリックすると枠に移動するか' do
       find('.member-name', text: '山田太郎').click
@@ -33,9 +41,7 @@ describe '3人組を探す機能' do
       end
 
       context 'ランチに行ったクウォーターと同じ期間の場合' do
-        it 'メンバーの表示が消えて選択できないこと' do
-          expect(find('#members-list')).to have_content('鈴木二郎')
-          expect(find('#members-list')).to have_content('鈴木三郎')
+        it 'すでにランチに行ったメンバーの表示が消えること' do
           find('.member-name', text: '鈴木一郎').click
           expect(find('#members-list')).to_not have_content('鈴木二郎')
           expect(find('#members-list')).to_not have_content('鈴木三郎')
@@ -48,9 +54,7 @@ describe '3人組を探す機能' do
           visit root_path
         end
 
-        it 'メンバーの選択ができること' do
-          expect(find('#members-list')).to have_content('鈴木二郎')
-          expect(find('#members-list')).to have_content('鈴木三郎')
+        it 'すでにランチに行ったメンバーが表示があること' do
           find('.member-name', text: '鈴木一郎').click
           expect(find('#members-list')).to have_content('鈴木二郎')
           expect(find('#members-list')).to have_content('鈴木三郎')

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -26,18 +26,35 @@ describe '3人組を探す機能' do
       end
     end
 
-    context 'すでにランチに行っているメンバー同士の組み合わせの場合' do
+    context 'すでにランチに行っているメンバー同士の組み合わせを選択する場合' do
       before do
         create(:lunch, members: [member1, member2, member3])
         visit root_path
       end
 
-      it 'メンバーの表示が消えて選択できない' do
-        expect(find('#members-list')).to have_content('鈴木二郎')
-        expect(find('#members-list')).to have_content('鈴木三郎')
-        find('.member-name', text: '鈴木一郎').click
-        expect(find('#members-list')).to_not have_content('鈴木二郎')
-        expect(find('#members-list')).to_not have_content('鈴木三郎')
+      context 'ランチに行ったクウォーターと同じ期間の場合' do
+        it 'メンバーの表示が消えて選択できないこと' do
+          expect(find('#members-list')).to have_content('鈴木二郎')
+          expect(find('#members-list')).to have_content('鈴木三郎')
+          find('.member-name', text: '鈴木一郎').click
+          expect(find('#members-list')).to_not have_content('鈴木二郎')
+          expect(find('#members-list')).to_not have_content('鈴木三郎')
+        end
+      end
+
+      context 'ランチに行ったクウォーターと違う期間の場合' do
+        before do
+          travel 3.month
+          visit root_path
+        end
+
+        it 'メンバーの選択ができること' do
+          expect(find('#members-list')).to have_content('鈴木二郎')
+          expect(find('#members-list')).to have_content('鈴木三郎')
+          find('.member-name', text: '鈴木一郎').click
+          expect(find('#members-list')).to have_content('鈴木二郎')
+          expect(find('#members-list')).to have_content('鈴木三郎')
+        end
       end
     end
   end


### PR DESCRIPTION
## Issue
close #14 

## 内容
- 現在のクウォーターだけを見てランチ給付金を使った組み合わせは選べないようにする

### 現在のクウォーターだけを見てランチ給付金を使った組み合わせは選べないようにする
ランチ給付金制度には利用履歴が四半期（３ヶ月ごと）でリセットされるというルールがあり、そのルールをこのアプリにも取り入れた。

いままでは、ランチに行く画面で選ぶメンバーは**すべての期間**の中でランチ履歴があるメンバー同士の組み合わせは選べないようになっていた。
このPRでは**現在のクウォーターの期間**の中でランチ履歴があるメンバー同士の組み合わせは選べないように限定することで、次の期間になるとまた同じメンバーを選べるようになるのでリセットのルールを実現した。

実装は現在のクウォーターのみの履歴のみにするscopeをLunchモデルに作るようにした。

実装を確認するために、scopeのテストとシステムテストを書いた。
<!--
なぜそれが必要か,
どのような変更をしたか,
確かめる手順または画像や動画,
など
-->

## 備考
<!--
このプルリクエストに関連しているが、このプルリクエストでは対応しないこと,
マージ先のブランチへマージする他のプルリクエストの順番,
など
-->
