### PR TITLE
表示を日本語に直す

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'select2-rails'
 gem 'materialize-sass', '~> 1.0.0'
 gem 'material_icons' 
 gem 'gon'
+gem 'rails-i18n'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -317,6 +320,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n
   rspec-rails (~> 3.8.0)
   rspec_junit_formatter
   sass-rails (~> 5.0)

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -8,7 +8,7 @@ class LunchesController < ApplicationController
     members = Member.where(real_name: params[:lunch][:members])
     @lunch = Lunch.new(date: Date.today, members: members)
     if @lunch.save
-      redirect_to root_url, notice: 'Lunch was successfully created.'
+      redirect_to root_url, notice: t('dictionary.message.create.complete', record: "#{@lunch.members.pluck(:real_name).join(',')}のランチ")
     else
       set_variables_for_new_lunch_view
       render :new

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -16,7 +16,7 @@ class MembersController < ApplicationController
     @member = Member.new(member_params)
 
     if @member.save
-      redirect_to members_url, notice: 'Member was successfully created.'
+      redirect_to members_url, notice: t('dictionary.message.create.complete', record: @member.real_name)
     else
       render :new
     end
@@ -24,7 +24,7 @@ class MembersController < ApplicationController
 
   def update
     if @member.update(member_params)
-      redirect_to members_url, notice: 'Member was successfully updated.'
+      redirect_to members_url, notice: t('dictionary.message.update.complete', record: @member.real_name)
     else
       render :edit
     end
@@ -32,7 +32,7 @@ class MembersController < ApplicationController
 
   def destroy
     @member.destroy
-    redirect_to members_url, notice: 'Member was successfully destroyed.'
+    redirect_to members_url, notice: t('dictionary.message.destroy.complete', record: @member.real_name)
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,7 +19,7 @@ class ProjectsController < ApplicationController
     @project = Project.new(project_params)
 
     if @project.save
-      redirect_to projects_url, notice: 'Project was successfully created.'
+      redirect_to projects_url, notice: t('dictionary.message.create.complete', record: @project.name)
     else
       render :new
     end
@@ -27,7 +27,7 @@ class ProjectsController < ApplicationController
 
   def update
     if @project.update(project_params)
-      redirect_to projects_url, notice: 'Project was successfully updated.'
+      redirect_to projects_url, notice: t('dictionary.message.update.complete', record: @project.name)
     else
       render :edit
     end
@@ -35,7 +35,7 @@ class ProjectsController < ApplicationController
 
   def destroy
     @project.destroy
-    redirect_to projects_url, notice: 'Project was successfully destroyed.'
+    redirect_to projects_url, notice: t('dictionary.message.destroy.complete', record: @project.name)
   end
 
   private

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -19,10 +19,10 @@ h3 ランチに行くメンバーを探す
             - @lunch.errors.messages.values.flatten.each do |message|
               li = message
       .input-field
-        = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'member-form center-align white black-text' 
-      .input-field 
         = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'member-form center-align white black-text'
-      .input-field  
+      .input-field
+        = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'member-form center-align white black-text'
+      .input-field
         = f.text_field :member, name: 'lunch[members][]', readonly: true, class: 'member-form center-align white black-text'
       .center-align
         = f.submit 'ランチに行く', id: 'submit-btn', class: 'btn-large text-white'

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -5,9 +5,9 @@ h3 メンバー
 table
   thead
     tr
-      th Hundle name
-      th Real name
-      th プロジェクト
+      th = Member.human_attribute_name(:hundle_name)
+      th = Member.human_attribute_name(:real_name)
+      th = Member.human_attribute_name(:projects)
       th
 
   tbody

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -19,4 +19,4 @@ table
         td 
           = link_to mi.edit, edit_member_path(member), class: 'btn-small z-depth-0 edit-btn'
           |  
-          = link_to mi.delete , member, data: { confirm: 'Are you sure?' }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+          = link_to mi.delete , member, data: { confirm: t('dictionary.message.destroy.confirm') }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -1,3 +1,4 @@
+= render 'layouts/flash_messages'
 h3 メンバー
 = link_to new_member_path, id: 'new-btn', class: 'btn right'
   == material_icon.add
@@ -16,7 +17,7 @@ table
         td = member.hundle_name
         td = member.real_name
         td = project_list(member)
-        td 
+        td
           = link_to mi.edit, edit_member_path(member), class: 'btn-small z-depth-0 edit-btn'
           |  
-          = link_to mi.delete , member, data: { confirm: t('dictionary.message.destroy.confirm') }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+          = link_to mi.delete , member, data: { confirm: t('dictionary.message.destroy.confirm', record: member.real_name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -1,3 +1,4 @@
+= render 'layouts/flash_messages'
 h3 プロジェクト
 = link_to new_project_path, id: 'new-btn', class: 'btn right'
   == material_icon.add
@@ -13,7 +14,7 @@ table
     - @projects.each do |project|
       tr
         td = project.name
-        td 
+        td
           = link_to mi.edit, edit_project_path(project), class: 'btn-small z-depth-0 edit-btn'
           |  
-          = link_to mi.delete, project, data: { confirm: t('dictionary.message.destroy.confirm') }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+          = link_to mi.delete, project, data: { confirm: t('dictionary.message.destroy.confirm', record: project.name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -16,4 +16,4 @@ table
         td 
           = link_to mi.edit, edit_project_path(project), class: 'btn-small z-depth-0 edit-btn'
           |  
-          = link_to mi.delete, project, data: { confirm: 'Are you sure?' }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+          = link_to mi.delete, project, data: { confirm: t('dictionary.message.destroy.confirm') }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -6,7 +6,7 @@ h3 プロジェクト
 table
   thead
     tr
-      th Name
+      th = Project.human_attribute_name(:name)
       th
 
   tbody

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,1 @@
+Rails.application.config.i18n.default_locale = :ja

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,6 @@
 ja:
   activerecord:
-    models: 
+    models:
       member: メンバー
       project: プロジェクト
     attributes:
@@ -10,11 +10,13 @@ ja:
         projects: 所属プロジェクト
       project:
         name: プロジェクト名
+
   dictionary:
     message:
       create:
-        complete: 登録しました
+        complete: "%{record}を登録しました"
       update:
-        complete: 更新しました
+        complete: "%{record}を更新しました"
       destroy:
-        confirm: 削除しますか？
+        complete: "%{record}を削除しました"
+        confirm: "%{record}を削除しますか？"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,20 @@
+ja:
+  activerecord:
+    models: 
+      member: メンバー
+      project: プロジェクト
+    attributes:
+      member:
+        hundle_name: ニックネーム
+        real_name: 氏名
+        projects: 所属プロジェクト
+      project:
+        name: プロジェクト名
+  dictionary:
+    message:
+      create:
+        complete: 登録しました
+      update:
+        complete: 更新しました
+      destroy:
+        confirm: 削除しますか？

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -49,7 +49,7 @@ describe '3人組を探す機能' do
         find('.member-name', text: '鈴木二郎').click
         find('.member-name', text: '鈴木三郎').click
         find('#submit-btn').click
-        expect(page).to have_content 'Lunch was successfully created.'
+        expect(page).to have_content '鈴木一郎,鈴木二郎,鈴木三郎のランチを登録しました'
       end
     end
 

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -32,8 +32,8 @@ describe 'メンバー管理機能', type: :system do
       it '新規に追加できないこと' do
         find('#new-btn').click
         find('#submit-btn').click
-        expect(page).to have_content "Hundle name can't be blank"
-        expect(page).to have_content "Real name can't be blank"
+        expect(page).to have_content "ニックネームを入力してください"
+        expect(page).to have_content "氏名を入力してください"
       end
     end
   end

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -23,8 +23,7 @@ describe 'メンバー管理機能', type: :system do
         fill_in 'member[hundle_name]', with: 'hanako'
         fill_in 'member[real_name]', with: '山田花子'
         find('#submit-btn').click
-        expect(page).to have_content 'hanako'
-        expect(page).to have_content '山田花子'
+        expect(page).to have_content '山田花子を登録しました'
       end
     end
 
@@ -44,8 +43,8 @@ describe 'メンバー管理機能', type: :system do
       fill_in 'member[hundle_name]', with: 'taro3'
       fill_in 'member[real_name]', with: '山下太郎'
       find('#submit-btn').click
+      expect(page).to have_content '山下太郎を更新しました'
       expect(page).to have_content 'taro3'
-      expect(page).to have_content '山下太郎'
     end
 
     it 'プロジェクトを選択できるか' do
@@ -61,8 +60,7 @@ describe 'メンバー管理機能', type: :system do
     it '削除できるか' do
       find('.delete-btn').click
       page.driver.browser.switch_to.alert.accept
-      expect(page).to_not have_content 'taro'
-      expect(page).to_not have_content '山田太郎'
+      expect(page).to have_content '山田太郎を削除しました'
     end
   end
 end

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -31,8 +31,8 @@ describe 'メンバー管理機能', type: :system do
       it '新規に追加できないこと' do
         find('#new-btn').click
         find('#submit-btn').click
-        expect(page).to have_content "ニックネームを入力してください"
-        expect(page).to have_content "氏名を入力してください"
+        expect(page).to have_content 'ニックネームを入力してください'
+        expect(page).to have_content '氏名を入力してください'
       end
     end
   end

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -28,7 +28,7 @@ describe 'プロジェクト管理機能' do
       it '新規に追加できないこと' do
         find('#new-btn').click
         find('#submit-btn').click
-        expect(page).to have_content "Name can't be blank"
+        expect(page).to have_content "プロジェクト名を入力してください"
       end
     end
   end

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -20,7 +20,7 @@ describe 'プロジェクト管理機能' do
         find('#new-btn').click
         fill_in 'project[name]', with: 'プロダクト'
         find('#submit-btn').click
-        expect(page).to have_content 'プロダクト'
+        expect(page).to have_content 'プロダクトを登録しました'
       end
     end
 
@@ -38,7 +38,7 @@ describe 'プロジェクト管理機能' do
       find('.edit-btn').click
       fill_in 'project[name]', with: 'eiwasan'
       find('#submit-btn').click
-      expect(page).to have_content 'eiwasan'
+      expect(page).to have_content 'eiwasanを更新しました'
     end
   end
 
@@ -46,7 +46,7 @@ describe 'プロジェクト管理機能' do
     it '削除できるか' do
       find('.delete-btn').click
       page.driver.browser.switch_to.alert.accept
-      expect(page).to_not have_content 'eiwakun'
+      expect(page).to have_content 'eiwakunを削除しました'
     end
   end
 end

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -28,7 +28,7 @@ describe 'プロジェクト管理機能' do
       it '新規に追加できないこと' do
         find('#new-btn').click
         find('#submit-btn').click
-        expect(page).to have_content "プロジェクト名を入力してください"
+        expect(page).to have_content 'プロジェクト名を入力してください'
       end
     end
   end


### PR DESCRIPTION
## Issue
close #15 

## 内容
表示されるものはデフォルトのままで英語になっていたが、ユーザーは日本語の方が理解しやすいため日本語にした。

日本語に変更した箇所は、
- 登録と編集のsubmitボタン
- validationのエラーメッセージ
- テーブルのヘッダー
- 削除の確認ダイアログ
- レコード登録後に表示されるフラッシュメッセージ

`gem 'rails-i18n'`を使ってsubmitボタンとエラーメッセージを日本語に直した。

モデルに関するとこやそれ以外のメッセージは`config/locales/ja.yml`に日本語訳を書いて適用した 。
<!--
なぜそれが必要か,
どのような変更をしたか,
確かめる手順または画像や動画,
など
-->

## 備考
<!--
このプルリクエストに関連しているが、このプルリクエストでは対応しないこと,
マージ先のブランチへマージする他のプルリクエストの順番,
など
-->
