### PR TITLE
間違えて登録した給付金利用履歴を削除できる機能

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -14,11 +14,18 @@ class LunchesController < ApplicationController
     quarter = Quarter.find_or_create_quarter(today)
     @lunch = quarter.lunches.build(date: today, members: members)
     if @lunch.save
-      redirect_to lunches_url, notice: t('dictionary.message.create.complete', record: "#{@lunch.members.pluck(:real_name).join(',')}のランチ")
+      redirect_to lunches_url, notice: t('dictionary.message.create.complete', record: @lunch.record_text)
     else
       set_variables_for_new_lunch_view
       render :new
     end
+  end
+
+  def destroy
+    @lunch = Lunch.find(params[:id])
+    record_text = @lunch.record_text
+    @lunch.destroy
+    redirect_to lunches_url, notice: t('dictionary.message.destroy.complete', record: record_text)
   end
 
   private

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -1,6 +1,6 @@
 class LunchesController < ApplicationController
   def index
-    @quarters = Quarter.includes(lunches: [:lunches_members, :members, :user]).order("quarters.start_date" ,"lunches.date desc")
+    @quarters = Quarter.includes(lunches: [:lunches_members, :members, :created_by]).order("quarters.start_date" ,"lunches.date desc")
   end
 
   def new
@@ -12,7 +12,7 @@ class LunchesController < ApplicationController
     today = Date.today
     members = Member.where(real_name: params[:lunch][:members])
     quarter = Quarter.find_or_create_quarter(today)
-    @lunch = quarter.lunches.build(date: today, members: members, user: current_user)
+    @lunch = quarter.lunches.build(date: today, members: members, created_by: current_user)
     if @lunch.save
       redirect_to lunches_url, notice: t('dictionary.message.create.complete', record_label: @lunch.label_with_date_and_member_names)
     else

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -23,9 +23,14 @@ class LunchesController < ApplicationController
 
   def destroy
     @lunch = Lunch.find(params[:id])
-    record_label = @lunch.label_with_date_and_member_names
-    @lunch.destroy
-    redirect_to lunches_url, notice: t('dictionary.message.destroy.complete', record_label: record_label)
+
+    if @lunch.created_by == current_user
+      record_label = @lunch.label_with_date_and_member_names
+      @lunch.destroy
+      redirect_to lunches_url, notice: t('dictionary.message.destroy.complete', record_label: record_label)
+    else
+      redirect_to lunches_url, notice: '削除対象となったランチはあなたが作成したものではないので削除できませんでした'
+    end
   end
 
   private

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -14,7 +14,7 @@ class LunchesController < ApplicationController
     quarter = Quarter.find_or_create_quarter(today)
     @lunch = quarter.lunches.build(date: today, members: members)
     if @lunch.save
-      redirect_to lunches_url, notice: t('dictionary.message.create.complete', record_label: @lunch.record_label)
+      redirect_to lunches_url, notice: t('dictionary.message.create.complete', record_label: @lunch.label_with_member_names)
     else
       set_variables_for_new_lunch_view
       render :new
@@ -23,7 +23,7 @@ class LunchesController < ApplicationController
 
   def destroy
     @lunch = Lunch.find(params[:id])
-    record_label = @lunch.record_label
+    record_label = @lunch.label_with_member_names
     @lunch.destroy
     redirect_to lunches_url, notice: t('dictionary.message.destroy.complete', record_label: record_label)
   end

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -1,6 +1,6 @@
 class LunchesController < ApplicationController
   def index
-    @quarters = Quarter.includes(lunches: [:lunches_members, :members]).order("quarters.start_date" ,"lunches.date desc")
+    @quarters = Quarter.includes(lunches: [:lunches_members, :members, :user]).order("quarters.start_date" ,"lunches.date desc")
   end
 
   def new

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -12,7 +12,7 @@ class LunchesController < ApplicationController
     today = Date.today
     members = Member.where(real_name: params[:lunch][:members])
     quarter = Quarter.find_or_create_quarter(today)
-    @lunch = quarter.lunches.build(date: today, members: members)
+    @lunch = quarter.lunches.build(date: today, members: members, user: current_user)
     if @lunch.save
       redirect_to lunches_url, notice: t('dictionary.message.create.complete', record_label: @lunch.label_with_date_and_member_names)
     else

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -14,7 +14,7 @@ class LunchesController < ApplicationController
     quarter = Quarter.find_or_create_quarter(today)
     @lunch = quarter.lunches.build(date: today, members: members)
     if @lunch.save
-      redirect_to lunches_url, notice: t('dictionary.message.create.complete', record: @lunch.record_text)
+      redirect_to lunches_url, notice: t('dictionary.message.create.complete', record_label: @lunch.record_label)
     else
       set_variables_for_new_lunch_view
       render :new
@@ -23,9 +23,9 @@ class LunchesController < ApplicationController
 
   def destroy
     @lunch = Lunch.find(params[:id])
-    record_text = @lunch.record_text
+    record_label = @lunch.record_label
     @lunch.destroy
-    redirect_to lunches_url, notice: t('dictionary.message.destroy.complete', record: record_text)
+    redirect_to lunches_url, notice: t('dictionary.message.destroy.complete', record_label: record_label)
   end
 
   private

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -14,7 +14,7 @@ class LunchesController < ApplicationController
     quarter = Quarter.find_or_create_quarter(today)
     @lunch = quarter.lunches.build(date: today, members: members)
     if @lunch.save
-      redirect_to lunches_url, notice: t('dictionary.message.create.complete', record_label: @lunch.label_with_member_names)
+      redirect_to lunches_url, notice: t('dictionary.message.create.complete', record_label: @lunch.label_with_date_and_member_names)
     else
       set_variables_for_new_lunch_view
       render :new
@@ -23,7 +23,7 @@ class LunchesController < ApplicationController
 
   def destroy
     @lunch = Lunch.find(params[:id])
-    record_label = @lunch.label_with_member_names
+    record_label = @lunch.label_with_date_and_member_names
     @lunch.destroy
     redirect_to lunches_url, notice: t('dictionary.message.destroy.complete', record_label: record_label)
   end

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -14,7 +14,7 @@ class LunchesController < ApplicationController
     quarter = Quarter.find_or_create_quarter(today)
     @lunch = quarter.lunches.build(date: today, members: members, created_by: current_user)
     if @lunch.save
-      redirect_to lunches_url, notice: t('dictionary.message.create.complete', record_label: @lunch.label_with_date_and_member_names)
+      redirect_to lunches_url, notice: t('dictionary.message.create.complete', resource_name: @lunch.label_with_date_and_member_names)
     else
       set_variables_for_new_lunch_view
       render :new
@@ -25,9 +25,9 @@ class LunchesController < ApplicationController
     @lunch = Lunch.find(params[:id])
 
     if @lunch.created_by == current_user
-      record_label = @lunch.label_with_date_and_member_names
+      resource_name = @lunch.label_with_date_and_member_names
       @lunch.destroy
-      redirect_to lunches_url, notice: t('dictionary.message.destroy.complete', record_label: record_label)
+      redirect_to lunches_url, notice: t('dictionary.message.destroy.complete', resource_name: resource_name)
     else
       redirect_to lunches_url, notice: '削除対象となったランチはあなたが作成したものではないので削除できませんでした'
     end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -16,7 +16,7 @@ class MembersController < ApplicationController
     @member = Member.new(member_params)
 
     if @member.save
-      redirect_to members_url, notice: t('dictionary.message.create.complete', record_label: @member.real_name)
+      redirect_to members_url, notice: t('dictionary.message.create.complete', resource_name: @member.real_name)
     else
       render :new
     end
@@ -24,7 +24,7 @@ class MembersController < ApplicationController
 
   def update
     if @member.update(member_params)
-      redirect_to members_url, notice: t('dictionary.message.update.complete', record_label: @member.real_name)
+      redirect_to members_url, notice: t('dictionary.message.update.complete', resource_name: @member.real_name)
     else
       render :edit
     end
@@ -32,7 +32,7 @@ class MembersController < ApplicationController
 
   def destroy
     @member.destroy
-    redirect_to members_url, notice: t('dictionary.message.destroy.complete', record_label: @member.real_name)
+    redirect_to members_url, notice: t('dictionary.message.destroy.complete', resource_name: @member.real_name)
   end
 
   private

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -16,7 +16,7 @@ class MembersController < ApplicationController
     @member = Member.new(member_params)
 
     if @member.save
-      redirect_to members_url, notice: t('dictionary.message.create.complete', record: @member.real_name)
+      redirect_to members_url, notice: t('dictionary.message.create.complete', record_label: @member.real_name)
     else
       render :new
     end
@@ -24,7 +24,7 @@ class MembersController < ApplicationController
 
   def update
     if @member.update(member_params)
-      redirect_to members_url, notice: t('dictionary.message.update.complete', record: @member.real_name)
+      redirect_to members_url, notice: t('dictionary.message.update.complete', record_label: @member.real_name)
     else
       render :edit
     end
@@ -32,7 +32,7 @@ class MembersController < ApplicationController
 
   def destroy
     @member.destroy
-    redirect_to members_url, notice: t('dictionary.message.destroy.complete', record: @member.real_name)
+    redirect_to members_url, notice: t('dictionary.message.destroy.complete', record_label: @member.real_name)
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,7 +19,7 @@ class ProjectsController < ApplicationController
     @project = Project.new(project_params)
 
     if @project.save
-      redirect_to projects_url, notice: t('dictionary.message.create.complete', record: @project.name)
+      redirect_to projects_url, notice: t('dictionary.message.create.complete', record_label: @project.name)
     else
       render :new
     end
@@ -27,7 +27,7 @@ class ProjectsController < ApplicationController
 
   def update
     if @project.update(project_params)
-      redirect_to projects_url, notice: t('dictionary.message.update.complete', record: @project.name)
+      redirect_to projects_url, notice: t('dictionary.message.update.complete', record_label: @project.name)
     else
       render :edit
     end
@@ -35,7 +35,7 @@ class ProjectsController < ApplicationController
 
   def destroy
     @project.destroy
-    redirect_to projects_url, notice: t('dictionary.message.destroy.complete', record: @project.name)
+    redirect_to projects_url, notice: t('dictionary.message.destroy.complete', record_label: @project.name)
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,7 +19,7 @@ class ProjectsController < ApplicationController
     @project = Project.new(project_params)
 
     if @project.save
-      redirect_to projects_url, notice: t('dictionary.message.create.complete', record_label: @project.name)
+      redirect_to projects_url, notice: t('dictionary.message.create.complete', resource_name: @project.name)
     else
       render :new
     end
@@ -27,7 +27,7 @@ class ProjectsController < ApplicationController
 
   def update
     if @project.update(project_params)
-      redirect_to projects_url, notice: t('dictionary.message.update.complete', record_label: @project.name)
+      redirect_to projects_url, notice: t('dictionary.message.update.complete', resource_name: @project.name)
     else
       render :edit
     end
@@ -35,7 +35,7 @@ class ProjectsController < ApplicationController
 
   def destroy
     @project.destroy
-    redirect_to projects_url, notice: t('dictionary.message.destroy.complete', record_label: @project.name)
+    redirect_to projects_url, notice: t('dictionary.message.destroy.complete', resource_name: @project.name)
   end
 
   private

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -5,6 +5,10 @@ class Lunch < ApplicationRecord
 
   BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
 
+  def record_text
+    "#{members.pluck(:real_name).join(',')}の給付金利用履歴"
+  end
+
   private
 
   def must_have_benefits_available_count_members

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -5,7 +5,7 @@ class Lunch < ApplicationRecord
 
   BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
 
-  def record_label
+  def label_with_member_names
     "#{members.pluck(:real_name).join(',')}の給付金利用履歴"
   end
 

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -1,4 +1,5 @@
 class Lunch < ApplicationRecord
+  belongs_to :user
   belongs_to :quarter
   has_and_belongs_to_many :members
   validate :must_have_benefits_available_count_members

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -1,5 +1,5 @@
 class Lunch < ApplicationRecord
-  belongs_to :user
+  belongs_to :created_by,  foreign_key: :user_id, class_name: 'User'
   belongs_to :quarter
   has_and_belongs_to_many :members
   validate :must_have_benefits_available_count_members

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -5,7 +5,7 @@ class Lunch < ApplicationRecord
 
   BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
 
-  def record_text
+  def record_label
     "#{members.pluck(:real_name).join(',')}の給付金利用履歴"
   end
 

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -5,8 +5,8 @@ class Lunch < ApplicationRecord
 
   BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
 
-  def label_with_member_names
-    "#{members.pluck(:real_name).join(',')}の給付金利用履歴"
+  def label_with_date_and_member_names
+    "#{date} #{members.pluck(:real_name).join(',')}の給付金利用履歴"
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :lunches
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/lunches/index.html.slim
+++ b/app/views/lunches/index.html.slim
@@ -22,4 +22,4 @@ ul.tabs
             td = lunch.members.pluck(:real_name).join(',')
             td
               - if lunch.created_by == current_user
-                = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record_label: lunch.label_with_date_and_member_names) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+                = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: lunch.label_with_date_and_member_names) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/lunches/index.html.slim
+++ b/app/views/lunches/index.html.slim
@@ -21,4 +21,5 @@ ul.tabs
             td = lunch.date
             td = lunch.members.pluck(:real_name).join(',')
             td
-              = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record_label: lunch.label_with_date_and_member_names) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+              - if lunch.user == current_user
+                = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record_label: lunch.label_with_date_and_member_names) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/lunches/index.html.slim
+++ b/app/views/lunches/index.html.slim
@@ -21,4 +21,4 @@ ul.tabs
             td = lunch.date
             td = lunch.members.pluck(:real_name).join(',')
             td
-              = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record_label: lunch.label_with_member_names) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+              = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record_label: lunch.label_with_date_and_member_names) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/lunches/index.html.slim
+++ b/app/views/lunches/index.html.slim
@@ -21,5 +21,5 @@ ul.tabs
             td = lunch.date
             td = lunch.members.pluck(:real_name).join(',')
             td
-              - if lunch.user == current_user
+              - if lunch.created_by == current_user
                 = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record_label: lunch.label_with_date_and_member_names) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/lunches/index.html.slim
+++ b/app/views/lunches/index.html.slim
@@ -14,8 +14,11 @@ ul.tabs
         tr
           th = Lunch.human_attribute_name(:date)
           th = Lunch.human_attribute_name(:members)
+          th
       tbody
         - quarter.lunches.each do |lunch|
           tr
             td = lunch.date
             td = lunch.members.pluck(:real_name).join(',')
+            td
+              = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record: lunch.record_text) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/lunches/index.html.slim
+++ b/app/views/lunches/index.html.slim
@@ -21,4 +21,4 @@ ul.tabs
             td = lunch.date
             td = lunch.members.pluck(:real_name).join(',')
             td
-              = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record: lunch.record_text) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+              = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record_label: lunch.record_label) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/lunches/index.html.slim
+++ b/app/views/lunches/index.html.slim
@@ -21,4 +21,4 @@ ul.tabs
             td = lunch.date
             td = lunch.members.pluck(:real_name).join(',')
             td
-              = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record_label: lunch.record_label) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+              = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', record_label: lunch.label_with_member_names) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -12,7 +12,7 @@ h3 ランチに行くメンバーを探す
               td.member-name = member.real_name
               td.member-project = member.projects.pluck(:name).join(',')
   .col.s6
-    = form_with model: @lunch, local: true do |f|
+    = form_with model: @lunch, local: true, class: 'lunch-form' do |f|
       - if @lunch.errors.any?
         #error_explanation.red-text
           ul

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -20,4 +20,4 @@ table
         td
           = link_to mi.edit, edit_member_path(member), class: 'btn-small z-depth-0 edit-btn'
           |  
-          = link_to mi.delete , member, data: { confirm: t('dictionary.message.destroy.confirm', record: member.real_name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+          = link_to mi.delete , member, data: { confirm: t('dictionary.message.destroy.confirm', record_label: member.real_name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -20,4 +20,4 @@ table
         td
           = link_to mi.edit, edit_member_path(member), class: 'btn-small z-depth-0 edit-btn'
           |  
-          = link_to mi.delete , member, data: { confirm: t('dictionary.message.destroy.confirm', record_label: member.real_name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+          = link_to mi.delete , member, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: member.real_name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -17,4 +17,4 @@ table
         td
           = link_to mi.edit, edit_project_path(project), class: 'btn-small z-depth-0 edit-btn'
           |  
-          = link_to mi.delete, project, data: { confirm: t('dictionary.message.destroy.confirm', record: project.name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+          = link_to mi.delete, project, data: { confirm: t('dictionary.message.destroy.confirm', record_label: project.name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -17,4 +17,4 @@ table
         td
           = link_to mi.edit, edit_project_path(project), class: 'btn-small z-depth-0 edit-btn'
           |  
-          = link_to mi.delete, project, data: { confirm: t('dictionary.message.destroy.confirm', record_label: project.name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+          = link_to mi.delete, project, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: project.name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,9 +18,9 @@ ja:
   dictionary:
     message:
       create:
-        complete: "%{record_label}を登録しました"
+        complete: "%{resource_name}を登録しました"
       update:
-        complete: "%{record_label}を更新しました"
+        complete: "%{resource_name}を更新しました"
       destroy:
-        complete: "%{record_label}を削除しました"
-        confirm: "%{record_label}を削除しますか？"
+        complete: "%{resource_name}を削除しました"
+        confirm: "%{resource_name}を削除しますか？"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,9 +18,9 @@ ja:
   dictionary:
     message:
       create:
-        complete: "%{record}を登録しました"
+        complete: "%{record_label}を登録しました"
       update:
-        complete: "%{record}を更新しました"
+        complete: "%{record_label}を更新しました"
       destroy:
-        complete: "%{record}を削除しました"
-        confirm: "%{record}を削除しますか？"
+        complete: "%{record_label}を削除しました"
+        confirm: "%{record_label}を削除しますか？"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'lunches#new'
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
-  resources :lunches, only: [:index, :create]
+  resources :lunches, only: [:index, :create, :destroy]
   resources :members, except: :show
   resources :projects, expect: :show
 end

--- a/db/migrate/20190909015506_add_user_ref_to_lunch.rb
+++ b/db/migrate/20190909015506_add_user_ref_to_lunch.rb
@@ -1,0 +1,5 @@
+class AddUserRefToLunch < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :lunches, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_05_044920) do
+ActiveRecord::Schema.define(version: 2019_09_09_015506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,9 @@ ActiveRecord::Schema.define(version: 2019_09_05_044920) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "quarter_id"
+    t.bigint "user_id"
     t.index ["quarter_id"], name: "index_lunches_on_quarter_id"
+    t.index ["user_id"], name: "index_lunches_on_user_id"
   end
 
   create_table "lunches_members", id: false, force: :cascade do |t|
@@ -88,4 +90,5 @@ ActiveRecord::Schema.define(version: 2019_09_05_044920) do
   add_foreign_key "assignments", "members"
   add_foreign_key "assignments", "projects"
   add_foreign_key "lunches", "quarters"
+  add_foreign_key "lunches", "users"
 end

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -13,18 +13,22 @@ describe 'ランチ履歴の表示機能' do
       create(:member, real_name: '鈴木三郎')
     ]
     login_user = create(:user)
-    sign_in login_user
-    visit root_path
     create_lunch(members, login_user, date: Date.new(2019,9,15))
     create_lunch(members, login_user, date: Date.new(2019,9,16))
     create_lunch(members, login_user, date: Date.new(2019,12,15))
+
+    sign_in login_user
+    visit root_path
   end
 
   it 'クオーターごとに履歴が表示される' do
     visit lunches_path
+
     expect(page).to have_content('2019-09-15')
     expect(page).to have_content('2019-09-16')
+
     click_on('40期-2Q')
+
     expect(page).to have_content('2019-12-15')
   end
 end
@@ -34,14 +38,17 @@ describe 'ランチ履歴を登録したユーザーだけその履歴を削除�
     create(:member, real_name: '鈴木一郎')
     create(:member, real_name: '鈴木二郎')
     create(:member, real_name: '鈴木三郎')
+
     sign_in create(:user)
     visit root_path
+
     find('.member-name', text: '鈴木一郎').click
     find('.member-name', text: '鈴木二郎').click
     find('.member-name', text: '鈴木三郎').click
     within('.lunch-form') do
       click_on('ランチに行く')
     end
+
     visit lunches_path
   end
 
@@ -50,6 +57,7 @@ describe 'ランチ履歴を登録したユーザーだけその履歴を削除�
       click_on('delete')
     end
     page.driver.browser.switch_to.alert.accept
+
     expect(page).to have_content('鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を削除しました')
     within('table') do
       expect(page).to_not have_content('鈴木一郎,鈴木二郎,鈴木三郎')
@@ -59,6 +67,7 @@ describe 'ランチ履歴を登録したユーザーだけその履歴を削除�
   it '他人が登録した履歴には削除ボタンが無いこと' do
     sign_in create(:user, email: 'other@esm.co.jp')
     visit lunches_path
+
     within('tr', text: '鈴木一郎,鈴木二郎,鈴木三郎') do
       expect(page).to_not have_content('delete')
     end
@@ -74,6 +83,7 @@ describe '3人組を探す機能' do
 
   before do
     create(:member, projects: [project])
+
     sign_in login_user
     visit root_path
   end
@@ -89,6 +99,7 @@ describe '3人組を探す機能' do
   describe 'メンバーを選択する' do
     it '名前をクリックすると枠に移動するか' do
       find('.member-name', text: '山田太郎').click
+
       expect(first('.member-form').value).to eq '山田太郎'
       expect(find('#members-list')).to_not have_content('山田太郎')
     end
@@ -96,6 +107,7 @@ describe '3人組を探す機能' do
     context '同じプロジェクトに所属するメンバー同士の組み合わせの場合' do
       it 'メンバーの表示が消えて選択できない' do
         find('.member-name', text: '山田太郎').click
+
         expect(find('#members-list')).to_not have_content('鈴木一郎')
       end
     end
@@ -103,12 +115,14 @@ describe '3人組を探す機能' do
     context 'すでにランチに行っているメンバー同士の組み合わせを選択する場合' do
       before do
         create_lunch([member1, member2, member3], login_user)
+
         visit root_path
       end
 
       context 'ランチに行ったクウォーターと同じ期間の場合' do
         it 'すでにランチに行ったメンバーの表示が消えること' do
           find('.member-name', text: '鈴木一郎').click
+
           expect(find('#members-list')).to_not have_content('鈴木二郎')
           expect(find('#members-list')).to_not have_content('鈴木三郎')
         end
@@ -122,6 +136,7 @@ describe '3人組を探す機能' do
 
         it 'すでにランチに行ったメンバーが表示があること' do
           find('.member-name', text: '鈴木一郎').click
+
           expect(find('#members-list')).to have_content('鈴木二郎')
           expect(find('#members-list')).to have_content('鈴木三郎')
         end
@@ -136,6 +151,7 @@ describe '3人組を探す機能' do
         find('.member-name', text: '鈴木二郎').click
         find('.member-name', text: '鈴木三郎').click
         find('#submit-btn').click
+
         expect(page).to have_content '鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました'
       end
     end
@@ -145,6 +161,7 @@ describe '3人組を探す機能' do
         find('.member-name', text: '鈴木一郎').click
         find('.member-name', text: '鈴木二郎').click
         find('#submit-btn').click
+
         expect(page).to have_content '3人のメンバーを入力してください'
       end
     end
@@ -153,6 +170,7 @@ describe '3人組を探す機能' do
   describe 'ログインしているユーザーが自動でフォームの一人目に入力される機能' do
     before do
       create(:member, real_name: 'ろぐいん', email: 'sample@esm.co.jp')
+
       visit root_path
     end
 

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -28,27 +28,38 @@ describe 'ランチ履歴の表示機能' do
   end
 end
 
-describe 'ランチ履歴の削除機能' do
+describe 'ランチ履歴を登録したユーザーだけその履歴を削除できる機能' do
   before do
-    members = [
-      create(:member, real_name: '鈴木一郎'),
-      create(:member, real_name: '鈴木二郎'),
-      create(:member, real_name: '鈴木三郎')
-    ]
+    create(:member, real_name: '鈴木一郎')
+    create(:member, real_name: '鈴木二郎')
+    create(:member, real_name: '鈴木三郎')
     sign_in create(:user)
     visit root_path
-    create_lunch(members, date: Date.new(2019,9,15))
+    find('.member-name', text: '鈴木一郎').click
+    find('.member-name', text: '鈴木二郎').click
+    find('.member-name', text: '鈴木三郎').click
+    within('.lunch-form') do
+      click_on('ランチに行く')
+    end
+    visit lunches_path
   end
 
-  it '削除ボタンを押すと履歴が削除できること' do
-    visit lunches_path
-    within('tr', text: '2019-09-15 鈴木一郎,鈴木二郎,鈴木三郎') do
+  it '自分の登録した履歴は削除ボタンから削除できること' do
+    within('tr', text: '鈴木一郎,鈴木二郎,鈴木三郎') do
       click_on('delete')
     end
     page.driver.browser.switch_to.alert.accept
-    expect(page).to have_content('2019-09-15 鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を削除しました')
+    expect(page).to have_content('鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を削除しました')
     within('table') do
-      expect(page).to_not have_content('2019-09-15 鈴木一郎,鈴木二郎,鈴木三郎')
+      expect(page).to_not have_content('鈴木一郎,鈴木二郎,鈴木三郎')
+    end
+  end
+
+  it '他人が登録した履歴には削除ボタンが無いこと' do
+    sign_in create(:user, email: 'other@esm.co.jp')
+    visit lunches_path
+    within('tr', text: '鈴木一郎,鈴木二郎,鈴木三郎') do
+      expect(page).to_not have_content('delete')
     end
   end
 end

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-def create_lunch(members, date: Date.today)
+def create_lunch(members, user, date: Date.today)
   quarter = Quarter.find_or_create_quarter(date)
-  create(:lunch, members: members, date: date, quarter: quarter)
+  create(:lunch, members: members, date: date, quarter: quarter, user: user)
 end
 
 describe 'ランチ履歴の表示機能' do
@@ -12,11 +12,12 @@ describe 'ランチ履歴の表示機能' do
       create(:member, real_name: '鈴木二郎'),
       create(:member, real_name: '鈴木三郎')
     ]
-    sign_in create(:user)
+    login_user = create(:user)
+    sign_in login_user
     visit root_path
-    create_lunch(members, date: Date.new(2019,9,15))
-    create_lunch(members, date: Date.new(2019,9,16))
-    create_lunch(members, date: Date.new(2019,12,15))
+    create_lunch(members, login_user, date: Date.new(2019,9,15))
+    create_lunch(members, login_user, date: Date.new(2019,9,16))
+    create_lunch(members, login_user, date: Date.new(2019,12,15))
   end
 
   it 'クオーターごとに履歴が表示される' do
@@ -69,10 +70,11 @@ describe '3人組を探す機能' do
   let!(:member1) { create(:member, real_name: '鈴木一郎', projects: [project]) }
   let!(:member2) { create(:member, real_name: '鈴木二郎') }
   let!(:member3) { create(:member, real_name: '鈴木三郎') }
+  let!(:login_user) { create(:user) }
 
   before do
     create(:member, projects: [project])
-    sign_in create(:user)
+    sign_in login_user
     visit root_path
   end
 
@@ -100,7 +102,7 @@ describe '3人組を探す機能' do
 
     context 'すでにランチに行っているメンバー同士の組み合わせを選択する場合' do
       before do
-        create_lunch([member1, member2, member3])
+        create_lunch([member1, member2, member3], login_user)
         visit root_path
       end
 

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -28,6 +28,29 @@ describe 'ランチ履歴の表示機能' do
   end
 end
 
+describe 'ランチ履歴の削除機能' do
+  before do
+    members = [
+      create(:member, real_name: '鈴木一郎'),
+      create(:member, real_name: '鈴木二郎'),
+      create(:member, real_name: '鈴木三郎')
+    ]
+    sign_in create(:user)
+    visit root_path
+    create_lunch(members, date: Date.new(2019,9,15))
+  end
+
+  it '削除ボタンを押すと履歴が削除できること' do
+    visit lunches_path
+    expect(page).to have_content('2019-09-15')
+    within('tr', text: '2019-09-15 鈴木一郎,鈴木二郎,鈴木三郎') do
+      click_on('delete')
+    end
+    page.driver.browser.switch_to.alert.accept
+    expect(page).to_not have_content('2019-09-15')
+  end
+end
+
 describe '3人組を探す機能' do
   let!(:project) { create(:project) }
   let!(:member1) { create(:member, real_name: '鈴木一郎', projects: [project]) }

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -121,7 +121,7 @@ describe '3人組を探す機能' do
         find('.member-name', text: '鈴木二郎').click
         find('.member-name', text: '鈴木三郎').click
         find('#submit-btn').click
-        expect(page).to have_content '鈴木一郎,鈴木二郎,鈴木三郎のランチを登録しました'
+        expect(page).to have_content '鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を登録しました'
       end
     end
 

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -42,12 +42,14 @@ describe 'ランチ履歴の削除機能' do
 
   it '削除ボタンを押すと履歴が削除できること' do
     visit lunches_path
-    expect(page).to have_content('2019-09-15')
     within('tr', text: '2019-09-15 鈴木一郎,鈴木二郎,鈴木三郎') do
       click_on('delete')
     end
     page.driver.browser.switch_to.alert.accept
-    expect(page).to_not have_content('2019-09-15')
+    expect(page).to have_content('2019-09-15 鈴木一郎,鈴木二郎,鈴木三郎の給付金利用履歴を削除しました')
+    within('table') do
+      expect(page).to_not have_content('2019-09-15 鈴木一郎,鈴木二郎,鈴木三郎')
+    end
   end
 end
 

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 def create_lunch(members, user, date: Date.today)
   quarter = Quarter.find_or_create_quarter(date)
-  create(:lunch, members: members, date: date, quarter: quarter, user: user)
+  create(:lunch, members: members, date: date, quarter: quarter, created_by: user)
 end
 
 describe 'ランチ履歴の表示機能' do


### PR DESCRIPTION
## Issue
close #38

## 内容
- 給付金利用履歴の削除できるようにした
- Lunchモデルを登録した際のフラッシュメッセージを「ランチ」から「給付金利用履歴」に変更

追加要件の機能
- ランチ履歴を登録したユーザーだけが削除できるようにした

### 給付金利用履歴の削除できるようにした
以前まで間違えて給付金利用履歴を登録してしまったら削除できなかったため、削除できるようにした。
履歴削除の確認ダイアログ、削除後のフラッシュメッセージにはわかりやすいように削除したいレコードのメンバー名を列挙するようにした。(`Lunch#record_text`)
「ランチ」だとユーザーに分かりづらいので「給付金利用履歴」をフラッシュメッセージに含めるようにした。これは登録時のメッセージにも適用することで統一した。

ユーザーは給付金利用履歴の画面にある削除ボタンを押すと対応する行の履歴を消すことができる。

[![Image from Gyazo](https://i.gyazo.com/37e0bc8c709e44b82866e3563127a908.gif)](https://gyazo.com/37e0bc8c709e44b82866e3563127a908)

###  Lunchモデルを登録した際のフラッシュメッセージを「ランチ」から「給付金利用履歴」に変更
履歴削除のメッセージに合わせて、登録時のメッセージを変更した。


### ランチ履歴を登録したユーザーだけが削除できるようにした
ランチ履歴を登録したユーザーだけがその履歴を削除できるように制限する機能をつくった。

LunchテーブルにUserへの外部キーをつけて、コントローラー側でLunchの登録時にcurrent_user(ログインしているユーザー)を紐付けるようにした。
View側では、ランチ給付金利用履歴ページのテーブルの各行に、current_userと一致するuser_idをもつランチ履歴にだけ削除ボタンを表示させるようにした。
<!--
なぜそれが必要か,
どのような変更をしたか,
確かめる手順または画像や動画,
など
-->

## 備考
#42 が先にマージされたらこのPRをmasterへマージさせる
<!--
このプルリクエストに関連しているが、このプルリクエストでは対応しないこと,
マージ先のブランチへマージする他のプルリクエストの順番,
など
-->