### PR TITLE
本番環境のLunchモデルとQuarterモデルを関連付けるRakeタスクを追加

### DIFF
--- a/lib/tasks/associate_models.rake
+++ b/lib/tasks/associate_models.rake
@@ -1,4 +1,5 @@
 namespace :associate_models do
+  # 本番環境の既存データメンテナンス用のタスクで一度実行したらもう使わない
   desc 'DBのLunchモデルとQuarterモデルのデータを関連付ける'
   task associate_lunch_and_quarter: :environment do
     Lunch.where(quarter: nil).each do |lunch|

--- a/lib/tasks/associate_models.rake
+++ b/lib/tasks/associate_models.rake
@@ -1,0 +1,9 @@
+namespace :associate_models do
+  desc 'DBのLunchモデルとQuarterモデルのデータを関連付ける'
+  task associate_lunch_and_quarter: :environment do
+    Lunch.where(quarter: nil).each do |lunch|
+      quarter = Quarter.find_or_create_quarter(lunch.date)
+      lunch.update!(quarter: quarter)
+    end
+  end
+end


### PR DESCRIPTION
## Issue
close #45 

## 内容
- 本番環境のLunchモデルとQuarterモデルを関連付けるRakeタスクを追加した

### 本番環境のLunchモデルとQuarterモデルを関連付けるRakeタスクを追加した
#42 でクォーターごとのランチ履歴が見られるようになったが、本番環境のDBにすでに入っている`Lunch`モデルのデータはまだどの`Quarter`モデルにも関連づけられていない。

そのため、DBの`Lunch`モデルと`Quarter`モデルのデータを関連付けるタスクを作成した。

実際に本番環境でタスクを実行して、すべての`Lunch`モデルのデータが`Quarter`モデルと関連付けられたことを確かめた。

```
$ rake associate_models:associate_lunch_and_quarter RAILS_ENV=production DATABASE_URL=postgres://***
```
<!--
なぜそれが必要か,
どのような変更をしたか,
確かめる手順または画像や動画,
など
-->

## 備考
<!--
このプルリクエストに関連しているが、このプルリクエストでは対応しないこと,
マージ先のブランチへマージする他のプルリクエストの順番,
など
-->
