### PR TITLE
ランチに行けないメンバーの理由を表示する機能

### DIFF
--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -1,26 +1,26 @@
 document.addEventListener('turbolinks:load', function() {
   $('.tabs').tabs();
 
-  const members = document.querySelectorAll('.member-row');
+  const memberRows = document.querySelectorAll('.member-row');
 
-  for(const member of members) {
-    member.addEventListener('click', function(){
+  for(const memberRow of memberRows) {
+    memberRow.addEventListener('click', function(){
       const forms = document.querySelectorAll('.member-form');
       if (Array.from(forms).every(form => form.value !==''))
         return;
 
-      if (!member.classList.contains('unselectable-row')){
-        member.classList.add('selected-row');
+      if (!memberRow.classList.contains('unselectable-row')){
+        memberRow.classList.add('selected-row');
 
         noDisplayMember();
 
         const form = findEmptyForm(forms);
-        form.value = member.querySelector('.member-name').textContent;
+        form.value = memberRow.querySelector('.member-name').textContent;
 
         form.addEventListener('click', function(){
           form.value = '';
-          member.classList.remove('selected-row');
-          noDisplayMember(members);
+          memberRow.classList.remove('selected-row');
+          noDisplayMember();
         });
       }
     });
@@ -29,27 +29,27 @@ document.addEventListener('turbolinks:load', function() {
   fillInFirstMemberWithLoginMember();
 
   function fillInFirstMemberWithLoginMember() {
-    for(const member of members) {
-      if (member.querySelector('.member-name').textContent === gon.login_member["real_name"])
-        member.click();
+    for(const memberRow of memberRows) {
+      if (memberRow.querySelector('.member-name').textContent === gon.login_member["real_name"])
+        memberRow.click();
     }
   }
   
 
   // どのメンバーを表示しないか
   function noDisplayMember(){
-    for(const member of members) {
-      member.classList.remove('unselectable-row');
-      member.querySelector('.unselectable-reason').textContent = '';
-      const bool1 = hasSameProjects(member);
-      const bool2 = isUsedBenefitWithSelectedMembers(member);
+    for(const memberRow of memberRows) {
+      memberRow.classList.remove('unselectable-row');
+      memberRow.querySelector('.unselectable-reason').textContent = '';
+      const bool1 = hasSameProjects(memberRow);
+      const bool2 = isUsedBenefitWithSelectedMembers(memberRow);
       if (bool1 || bool2){
-        member.classList.add('unselectable-row');
+        memberRow.classList.add('unselectable-row');
       }
     }
   }
 
-  function hasSameProjects(member) {
+  function hasSameProjects(memberRow) {
     const ns = [];
     const selectedProjects = Array
       .from(document.querySelectorAll('.selected-row'))
@@ -57,7 +57,7 @@ document.addEventListener('turbolinks:load', function() {
       .flat()
       .filter(n => n !== '');
     const selectedMemberRows = document.querySelectorAll('.selected-row');
-    const memberProjects = member.querySelector('.member-project').textContent.split(',').filter(n => n !== '');
+    const memberProjects = memberRow.querySelector('.member-project').textContent.split(',').filter(n => n !== '');
     for(const selectedMemberRow of selectedMemberRows) {
       const selectedMemberProjects = selectedMemberRow.querySelector('.member-project').textContent.split(',').filter(n => n !== '');
       if (existsIntersection(memberProjects, selectedMemberProjects)){
@@ -65,15 +65,15 @@ document.addEventListener('turbolinks:load', function() {
       }
     }
     if (ns.length > 0){
-      member.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と同じプロジェクトです。`;
+      memberRow.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と同じプロジェクトです。`;
       return true;
     } else {
       return false;
     };
   }
 
-  function isUsedBenefitWithSelectedMembers(member) {
-    const memberName = member.querySelector('.member-name').textContent;
+  function isUsedBenefitWithSelectedMembers(memberRow) {
+    const memberName = memberRow.querySelector('.member-name').textContent;
     const selectedNames = Array
       .from(document.querySelectorAll('.selected-row'))
       .map(row => row.querySelector('.member-name').textContent);
@@ -86,7 +86,7 @@ document.addEventListener('turbolinks:load', function() {
       }
     };
     if (ns.length > 0){
-      member.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と行ったことがあります。`;
+      memberRow.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と行ったことがあります。`;
       return true;
     } else {
       return false;

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -34,65 +34,51 @@ document.addEventListener('turbolinks:load', function() {
         memberRow.click();
     }
   }
-  
+
 
   // どのメンバーを表示しないか
   function noDisplayMember(){
     for(const memberRow of memberRows) {
       memberRow.classList.remove('unselectable-row');
       memberRow.querySelector('.unselectable-reason').textContent = '';
-      const bool1 = hasSameProjects(memberRow);
-      const bool2 = isUsedBenefitWithSelectedMembers(memberRow);
-      if (bool1 || bool2){
+      fillUnselectableReason(memberRow);
+      if (memberRow.querySelector('.unselectable-reason').textContent !== ''){
         memberRow.classList.add('unselectable-row');
       }
     }
   }
 
-  function hasSameProjects(memberRow) {
-    const ns = [];
-    const selectedProjects = Array
-      .from(document.querySelectorAll('.selected-row'))
-      .map(row => row.querySelector('.member-project').textContent.split(','))
-      .flat()
-      .filter(n => n !== '');
+  function fillUnselectableReason(memberRow){
     const selectedMemberRows = document.querySelectorAll('.selected-row');
     const memberProjects = memberRow.querySelector('.member-project').textContent.split(',').filter(n => n !== '');
-    for(const selectedMemberRow of selectedMemberRows) {
+    const memberName = memberRow.querySelector('.member-name').textContent;
+    const unselectableReason = memberRow.querySelector('.unselectable-reason');
+    const sameProjectMemberNamesInSelectedMembers = [];
+    const usedBenefitMemberNamesInSelectedMembers = [];
+
+    for (const selectedMemberRow of selectedMemberRows) {
       const selectedMemberProjects = selectedMemberRow.querySelector('.member-project').textContent.split(',').filter(n => n !== '');
-      if (existsIntersection(memberProjects, selectedMemberProjects)){
-        ns.push(selectedMemberRow.querySelector('.member-name').textContent);
+      if (existsIntersection(memberProjects, selectedMemberProjects)) {
+        sameProjectMemberNamesInSelectedMembers.push(selectedMemberRow.querySelector('.member-name').textContent);
+      }
+
+      const selectedMemberName = selectedMemberRow.querySelector('.member-name').textContent
+      for (const trio of gon.lunch_trios) {
+        const names = trio.map(e => e["real_name"]);
+        if ((names.includes(memberName)) && (names.includes(selectedMemberName))) {
+          usedBenefitMemberNamesInSelectedMembers.push(selectedMemberName);
+        }
       }
     }
-    if (ns.length > 0){
-      memberRow.querySelector('.unselectable-reason').innerHTML += `${ns.flat().join(',')}と同じプロジェクト`;
-      return true;
-    } else {
-      return false;
-    };
-  }
 
-  function isUsedBenefitWithSelectedMembers(memberRow) {
-    const memberName = memberRow.querySelector('.member-name').textContent;
-    const selectedNames = Array
-      .from(document.querySelectorAll('.selected-row'))
-      .map(row => row.querySelector('.member-name').textContent);
-    const ns = [];
-    for(const trio of gon.lunch_trios) {
-      const names = trio.map(e => e["real_name"]);
-      for(selectedName of selectedNames) {
-        if ((names.includes(memberName)) && (names.includes(selectedName)))
-          ns.push(selectedName);
-      }
-    };
-    if (ns.length > 0){
-      if (memberRow.querySelector('.unselectable-reason').textContent !== '')
-        memberRow.querySelector('.unselectable-reason').innerHTML += '<br>';
-      memberRow.querySelector('.unselectable-reason').innerHTML += `${ns.flat().join(',')}とランチ済み`;
-      return true;
-    } else {
-      return false;
-    };
+    if (sameProjectMemberNamesInSelectedMembers.length > 0) {
+      unselectableReason.innerHTML += `${sameProjectMemberNamesInSelectedMembers.flat().join(',')}と同じプロジェクト`;
+    }
+
+    if (usedBenefitMemberNamesInSelectedMembers.length > 0) {
+      if (unselectableReason.textContent !== '') {unselectableReason.innerHTML += '<br>';}
+      unselectableReason.innerHTML += `${usedBenefitMemberNamesInSelectedMembers.flat().join(',')}とランチ済み`;
+    }
   }
 
   function existsIntersection(arr1, arr2){

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -15,7 +15,7 @@ document.addEventListener('turbolinks:load', function() {
         noDisplayMember();
 
         const form = findEmptyForm(forms);
-        form.value = member.children[0].textContent;
+        form.value = member.children[1].textContent;
 
         form.addEventListener('click', function(){
           form.value = '';
@@ -23,7 +23,6 @@ document.addEventListener('turbolinks:load', function() {
           noDisplayMember(members);
         });
       }
-
     });
   }
 
@@ -31,7 +30,7 @@ document.addEventListener('turbolinks:load', function() {
 
   function fillInFirstMemberWithLoginMember() {
     for(const member of members) {
-      if (member.children[0].textContent === gon.login_member["real_name"])
+      if (member.children[1].textContent === gon.login_member["real_name"])
         member.click();
     }
   }
@@ -41,6 +40,8 @@ document.addEventListener('turbolinks:load', function() {
   function noDisplayMember(){
     for(const member of members) {
       member.classList.remove('unselectable-row');
+      member.children[0].textContent = '';
+
       if (hasSameProjects(member) || isUsedBenefitWithSelectedMembers(member)){
         member.classList.add('unselectable-row');
       }
@@ -50,24 +51,32 @@ document.addEventListener('turbolinks:load', function() {
   function hasSameProjects(member) {
     const selectedProjects = Array
       .from(document.querySelectorAll('.selected-row'))
-      .map(row => row.children[1].textContent.split(','))
+      .map(row => row.children[2].textContent.split(','))
       .flat()
       .filter(n => n !== '');
-    const memberProjects = member.children[1].textContent.split(',');
+    const memberProjects = member.children[2].textContent.split(',');
     return existsIntersection(memberProjects, selectedProjects);
   }
 
   function isUsedBenefitWithSelectedMembers(member) {
-    const memberName = member.children[0].textContent;
+    const memberName = member.children[1].textContent;
     const selectedNames = Array
       .from(document.querySelectorAll('.selected-row'))
-      .map(row => row.children[0].textContent);
+      .map(row => row.children[1].textContent);
+    const ns = [];
     for(const trio of gon.lunch_trios) {
       const names = trio.map(e => e["real_name"]);
-      if (names.some(name => name === memberName) && existsIntersection(names, selectedNames))
-        return true;
+      for(selectedName of selectedNames) {
+        if ((names.includes(memberName)) && (names.includes(selectedName)))
+          ns.push(selectedName);
+      }
     };
-    return false;
+    if (ns.length > 0){
+      member.children[0].textContent = `${ns.flat().join(',')}と行ったことがあります。`;
+      return true;
+    } else {
+      return false;
+    };
   }
 
   function existsIntersection(arr1, arr2){

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -41,21 +41,35 @@ document.addEventListener('turbolinks:load', function() {
     for(const member of members) {
       member.classList.remove('unselectable-row');
       member.children[0].textContent = '';
-
-      if (hasSameProjects(member) || isUsedBenefitWithSelectedMembers(member)){
+      const bool1 = hasSameProjects(member);
+      const bool2 = isUsedBenefitWithSelectedMembers(member);
+      if (bool1 || bool2){
         member.classList.add('unselectable-row');
       }
     }
   }
 
   function hasSameProjects(member) {
+    const ns = [];
     const selectedProjects = Array
       .from(document.querySelectorAll('.selected-row'))
       .map(row => row.children[2].textContent.split(','))
       .flat()
       .filter(n => n !== '');
-    const memberProjects = member.children[2].textContent.split(',');
-    return existsIntersection(memberProjects, selectedProjects);
+    const selectedMemberRows = document.querySelectorAll('.selected-row');
+    const memberProjects = member.children[2].textContent.split(',').filter(n => n !== '');
+    for(const selectedMemberRow of selectedMemberRows) {
+      const selectedMemberProjects = selectedMemberRow.children[2].textContent.split(',').filter(n => n !== '');
+      if (existsIntersection(memberProjects, selectedMemberProjects)){
+        ns.push(selectedMemberRow.children[1].textContent);
+      }
+    }
+    if (ns.length > 0){
+      member.children[0].textContent += `${ns.flat().join(',')}と同じプロジェクトです。`;
+      return true;
+    } else {
+      return false;
+    };
   }
 
   function isUsedBenefitWithSelectedMembers(member) {
@@ -72,7 +86,7 @@ document.addEventListener('turbolinks:load', function() {
       }
     };
     if (ns.length > 0){
-      member.children[0].textContent = `${ns.flat().join(',')}と行ったことがあります。`;
+      member.children[0].textContent += `${ns.flat().join(',')}と行ったことがあります。`;
       return true;
     } else {
       return false;

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -1,7 +1,7 @@
 document.addEventListener('turbolinks:load', function() {
   $('.tabs').tabs();
 
-  const members = document.querySelectorAll('.member');
+  const members = document.querySelectorAll('.member-row');
 
   for(const member of members) {
     member.addEventListener('click', function(){

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -65,7 +65,7 @@ document.addEventListener('turbolinks:load', function() {
       }
     }
     if (ns.length > 0){
-      memberRow.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と同じプロジェクトです。`;
+      memberRow.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と同じプロジェクト`;
       return true;
     } else {
       return false;
@@ -86,7 +86,7 @@ document.addEventListener('turbolinks:load', function() {
       }
     };
     if (ns.length > 0){
-      memberRow.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と行ったことがあります。`;
+      memberRow.querySelector('.unselectable-reason').textContent += `\n${ns.flat().join(',')}とランチ済み`;
       return true;
     } else {
       return false;

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -12,7 +12,7 @@ document.addEventListener('turbolinks:load', function() {
       if (!memberRow.classList.contains('unselectable-row')){
         memberRow.classList.add('selected-row');
 
-        noDisplayMember();
+        ProcessUnselectableMemberRows();
 
         const form = findEmptyForm(forms);
         form.value = memberRow.querySelector('.member-name').textContent;
@@ -20,7 +20,7 @@ document.addEventListener('turbolinks:load', function() {
         form.addEventListener('click', function(){
           form.value = '';
           memberRow.classList.remove('selected-row');
-          noDisplayMember();
+          ProcessUnselectableMemberRows();
         });
       }
     });
@@ -35,9 +35,8 @@ document.addEventListener('turbolinks:load', function() {
     }
   }
 
-
-  // どのメンバーを表示しないか
-  function noDisplayMember(){
+  // 選択できないメンバーに関する処理
+  function ProcessUnselectableMemberRows(){
     for(const memberRow of memberRows) {
       memberRow.classList.remove('unselectable-row');
       memberRow.querySelector('.unselectable-reason').textContent = '';

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -9,18 +9,21 @@ document.addEventListener('turbolinks:load', function() {
       if (Array.from(forms).every(form => form.value !==''))
         return;
 
-      member.classList.add('selected-row');
+      if (!member.classList.contains('unselectable-row')){
+        member.classList.add('selected-row');
 
-      noDisplayMember(members);
+        noDisplayMember();
 
-      const form = findEmptyForm(forms);
-      form.value = member.children[0].textContent;
+        const form = findEmptyForm(forms);
+        form.value = member.children[0].textContent;
 
-      form.addEventListener('click', function(){
-        form.value = '';
-        member.classList.remove('selected-row');
-        noDisplayMember(members);
-      });
+        form.addEventListener('click', function(){
+          form.value = '';
+          member.classList.remove('selected-row');
+          noDisplayMember(members);
+        });
+      }
+
     });
   }
 
@@ -35,11 +38,12 @@ document.addEventListener('turbolinks:load', function() {
   
 
   // どのメンバーを表示しないか
-  function noDisplayMember(members){
+  function noDisplayMember(){
     for(const member of members) {
       member.classList.remove('unselectable-row');
-      if (hasSameProjects(member) || isUsedBenefitWithSelectedMembers(member))
+      if (hasSameProjects(member) || isUsedBenefitWithSelectedMembers(member)){
         member.classList.add('unselectable-row');
+      }
     }
   }
 

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -12,7 +12,7 @@ document.addEventListener('turbolinks:load', function() {
       if (!memberRow.classList.contains('unselectable-row')){
         memberRow.classList.add('selected-row');
 
-        addUnselectableReasonAndClassToUnselectableMemberRows();
+        makeUnselectableRows();
 
         const form = findEmptyForm(forms);
         form.value = memberRow.querySelector('.member-name').textContent;
@@ -20,7 +20,7 @@ document.addEventListener('turbolinks:load', function() {
         form.addEventListener('click', function(){
           form.value = '';
           memberRow.classList.remove('selected-row');
-          addUnselectableReasonAndClassToUnselectableMemberRows();
+          makeUnselectableRows();
         });
       }
     });
@@ -36,16 +36,18 @@ document.addEventListener('turbolinks:load', function() {
   }
 
   // 選択できないメンバーに関する処理
-  function addUnselectableReasonAndClassToUnselectableMemberRows(){
+  function makeUnselectableRows(){
     for(const memberRow of memberRows) {
       memberRow.classList.remove('unselectable-row');
       memberRow.querySelector('.unselectable-reason').textContent = '';
-      addUnselectableReasonIfMemberRowIsUnselectable(memberRow);
-      addClassIfUnselectableReasonIsFilled(memberRow)
+      addUnselectableReason(memberRow);
+      if (memberRow.querySelector('.unselectable-reason').textContent !== ''){
+        visualizeUnselectable(memberRow);
+      }
     }
   }
 
-  function addUnselectableReasonIfMemberRowIsUnselectable(memberRow){
+  function addUnselectableReason(memberRow){
     const selectedMemberRows = document.querySelectorAll('.selected-row');
     const memberProjects = memberRow.querySelector('.member-project').textContent.split(',').filter(n => n !== '');
     const memberName = memberRow.querySelector('.member-name').textContent;
@@ -78,10 +80,8 @@ document.addEventListener('turbolinks:load', function() {
     }
   }
 
-  function addClassIfUnselectableReasonIsFilled(memberRow) {
-    if (memberRow.querySelector('.unselectable-reason').textContent !== ''){
-      memberRow.classList.add('unselectable-row');
-    }
+  function visualizeUnselectable(memberRow) {
+    memberRow.classList.add('unselectable-row');
   }
 
   function existsIntersection(arr1, arr2){

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -65,7 +65,7 @@ document.addEventListener('turbolinks:load', function() {
       }
     }
     if (ns.length > 0){
-      memberRow.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と同じプロジェクト`;
+      memberRow.querySelector('.unselectable-reason').innerHTML += `${ns.flat().join(',')}と同じプロジェクト`;
       return true;
     } else {
       return false;
@@ -86,7 +86,9 @@ document.addEventListener('turbolinks:load', function() {
       }
     };
     if (ns.length > 0){
-      memberRow.querySelector('.unselectable-reason').textContent += `\n${ns.flat().join(',')}とランチ済み`;
+      if (memberRow.querySelector('.unselectable-reason').textContent !== '')
+        memberRow.querySelector('.unselectable-reason').innerHTML += '<br>';
+      memberRow.querySelector('.unselectable-reason').innerHTML += `${ns.flat().join(',')}とランチ済み`;
       return true;
     } else {
       return false;

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -15,7 +15,7 @@ document.addEventListener('turbolinks:load', function() {
         noDisplayMember();
 
         const form = findEmptyForm(forms);
-        form.value = member.children[1].textContent;
+        form.value = member.querySelector('.member-name').textContent;
 
         form.addEventListener('click', function(){
           form.value = '';
@@ -30,7 +30,7 @@ document.addEventListener('turbolinks:load', function() {
 
   function fillInFirstMemberWithLoginMember() {
     for(const member of members) {
-      if (member.children[1].textContent === gon.login_member["real_name"])
+      if (member.querySelector('.member-name').textContent === gon.login_member["real_name"])
         member.click();
     }
   }
@@ -40,7 +40,7 @@ document.addEventListener('turbolinks:load', function() {
   function noDisplayMember(){
     for(const member of members) {
       member.classList.remove('unselectable-row');
-      member.children[0].textContent = '';
+      member.querySelector('.unselectable-reason').textContent = '';
       const bool1 = hasSameProjects(member);
       const bool2 = isUsedBenefitWithSelectedMembers(member);
       if (bool1 || bool2){
@@ -53,19 +53,19 @@ document.addEventListener('turbolinks:load', function() {
     const ns = [];
     const selectedProjects = Array
       .from(document.querySelectorAll('.selected-row'))
-      .map(row => row.children[2].textContent.split(','))
+      .map(row => row.querySelector('.member-project').textContent.split(','))
       .flat()
       .filter(n => n !== '');
     const selectedMemberRows = document.querySelectorAll('.selected-row');
-    const memberProjects = member.children[2].textContent.split(',').filter(n => n !== '');
+    const memberProjects = member.querySelector('.member-project').textContent.split(',').filter(n => n !== '');
     for(const selectedMemberRow of selectedMemberRows) {
-      const selectedMemberProjects = selectedMemberRow.children[2].textContent.split(',').filter(n => n !== '');
+      const selectedMemberProjects = selectedMemberRow.querySelector('.member-project').textContent.split(',').filter(n => n !== '');
       if (existsIntersection(memberProjects, selectedMemberProjects)){
-        ns.push(selectedMemberRow.children[1].textContent);
+        ns.push(selectedMemberRow.querySelector('.member-name').textContent);
       }
     }
     if (ns.length > 0){
-      member.children[0].textContent += `${ns.flat().join(',')}と同じプロジェクトです。`;
+      member.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と同じプロジェクトです。`;
       return true;
     } else {
       return false;
@@ -73,10 +73,10 @@ document.addEventListener('turbolinks:load', function() {
   }
 
   function isUsedBenefitWithSelectedMembers(member) {
-    const memberName = member.children[1].textContent;
+    const memberName = member.querySelector('.member-name').textContent;
     const selectedNames = Array
       .from(document.querySelectorAll('.selected-row'))
-      .map(row => row.children[1].textContent);
+      .map(row => row.querySelector('.member-name').textContent);
     const ns = [];
     for(const trio of gon.lunch_trios) {
       const names = trio.map(e => e["real_name"]);
@@ -86,7 +86,7 @@ document.addEventListener('turbolinks:load', function() {
       }
     };
     if (ns.length > 0){
-      member.children[0].textContent += `${ns.flat().join(',')}と行ったことがあります。`;
+      member.querySelector('.unselectable-reason').textContent += `${ns.flat().join(',')}と行ったことがあります。`;
       return true;
     } else {
       return false;

--- a/app/assets/javascripts/lunch.js
+++ b/app/assets/javascripts/lunch.js
@@ -12,7 +12,7 @@ document.addEventListener('turbolinks:load', function() {
       if (!memberRow.classList.contains('unselectable-row')){
         memberRow.classList.add('selected-row');
 
-        ProcessUnselectableMemberRows();
+        addUnselectableReasonAndClassToUnselectableMemberRows();
 
         const form = findEmptyForm(forms);
         form.value = memberRow.querySelector('.member-name').textContent;
@@ -20,7 +20,7 @@ document.addEventListener('turbolinks:load', function() {
         form.addEventListener('click', function(){
           form.value = '';
           memberRow.classList.remove('selected-row');
-          ProcessUnselectableMemberRows();
+          addUnselectableReasonAndClassToUnselectableMemberRows();
         });
       }
     });
@@ -36,18 +36,16 @@ document.addEventListener('turbolinks:load', function() {
   }
 
   // 選択できないメンバーに関する処理
-  function ProcessUnselectableMemberRows(){
+  function addUnselectableReasonAndClassToUnselectableMemberRows(){
     for(const memberRow of memberRows) {
       memberRow.classList.remove('unselectable-row');
       memberRow.querySelector('.unselectable-reason').textContent = '';
-      fillUnselectableReason(memberRow);
-      if (memberRow.querySelector('.unselectable-reason').textContent !== ''){
-        memberRow.classList.add('unselectable-row');
-      }
+      addUnselectableReasonIfMemberRowIsUnselectable(memberRow);
+      addClassIfUnselectableReasonIsFilled(memberRow)
     }
   }
 
-  function fillUnselectableReason(memberRow){
+  function addUnselectableReasonIfMemberRowIsUnselectable(memberRow){
     const selectedMemberRows = document.querySelectorAll('.selected-row');
     const memberProjects = memberRow.querySelector('.member-project').textContent.split(',').filter(n => n !== '');
     const memberName = memberRow.querySelector('.member-name').textContent;
@@ -77,6 +75,12 @@ document.addEventListener('turbolinks:load', function() {
     if (usedBenefitMemberNamesInSelectedMembers.length > 0) {
       if (unselectableReason.textContent !== '') {unselectableReason.innerHTML += '<br>';}
       unselectableReason.innerHTML += `${usedBenefitMemberNamesInSelectedMembers.flat().join(',')}とランチ済み`;
+    }
+  }
+
+  function addClassIfUnselectableReasonIsFilled(memberRow) {
+    if (memberRow.querySelector('.unselectable-reason').textContent !== ''){
+      memberRow.classList.add('unselectable-row');
     }
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,5 +47,6 @@ body{
 }
 
 .unselectable-row{
-  display: none;
+  background-color: gray;
+  cursor: not-allowed;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,6 +47,6 @@ body{
 }
 
 .unselectable-row{
-  background-color: gray;
+  @extend .grey, .lighten-2;
   cursor: not-allowed;
 }

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -8,14 +8,14 @@ h3 ランチに行くメンバーを探す
       #members-list
         table#member-table
           tr
-            th 選べない理由
             th = Member.human_attribute_name(:real_name)
             th = Member.human_attribute_name(:projects)
+            th 選べない理由
           - @members.each do |member|
             tr.member-row
-              td.unselectable-reason
               td.member-name = member.real_name
               td.member-project = member.projects.pluck(:name).join(',')
+              td.unselectable-reason
   .col.s3
     = form_with model: @lunch, local: true, class: 'lunch-form' do |f|
       - if @lunch.errors.any?

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -8,7 +8,7 @@ h3 ランチに行くメンバーを探す
       #members-list
         table#member-table.highlight
           - @members.each do |member|
-            tr.member
+            tr.member-row
               td.member-name = member.real_name
               td.member-project = member.projects.pluck(:name).join(',')
   .col.s6

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -6,7 +6,7 @@ h3 ランチに行くメンバーを探す
     .card-panel
       p class='teal-text'リストからメンバーを選んでください。
       #members-list
-        table#member-table.highlight
+        table#member-table
           - @members.each do |member|
             tr.member-row
               td.member-name = member.real_name

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -7,6 +7,10 @@ h3 ランチに行くメンバーを探す
       p class='teal-text'リストからメンバーを選んでください。
       #members-list
         table#member-table
+          tr
+            th 選べない理由
+            th = Member.human_attribute_name(:real_name)
+            th = Member.human_attribute_name(:projects)
           - @members.each do |member|
             tr.member-row
               td.unselectable-reason

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -9,6 +9,7 @@ h3 ランチに行くメンバーを探す
         table#member-table
           - @members.each do |member|
             tr.member-row
+              td.unselectable-reason
               td.member-name = member.real_name
               td.member-project = member.projects.pluck(:name).join(',')
   .col.s6

--- a/app/views/lunches/new.html.slim
+++ b/app/views/lunches/new.html.slim
@@ -2,7 +2,7 @@
 h3 ランチに行くメンバーを探す
 
 .row
-  .col.s6
+  .col.s9
     .card-panel
       p class='teal-text'リストからメンバーを選んでください。
       #members-list
@@ -16,7 +16,7 @@ h3 ランチに行くメンバーを探す
               td.unselectable-reason
               td.member-name = member.real_name
               td.member-project = member.projects.pluck(:name).join(',')
-  .col.s6
+  .col.s3
     = form_with model: @lunch, local: true, class: 'lunch-form' do |f|
       - if @lunch.errors.any?
         #error_explanation.red-text

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,8 @@
 require "csv"
 require 'yaml'
 
+User.create!(email: 'sample@esm.co.jp', password: 'password')
+
 CSV.foreach('db/seed/member.csv', headers: true) do |row|
   Member.create!(
     hundle_name: row['GitHub'],
@@ -19,6 +21,7 @@ CSV.foreach('db/seed/lunch-40-1Q.csv') do |row|
   quarter = Quarter.find_or_create_quarter(date)
   quarter.lunches.create!(
     date: date,
-    members: Member.where(real_name: names)
+    members: Member.where(real_name: names),
+    created_by: User.find_by(email: 'sample@esm.co.jp')
   )
 end

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :member do
-    hundle_name { 'taro' }
-    real_name { '山田太郎' }
+    hundle_name { 'eiwa' }
+    real_name { '永和太郎' }
   end
 end

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -82,7 +82,7 @@ describe '3人組を探す機能' do
   let!(:login_user) { create(:user) }
 
   before do
-    create(:member, projects: [project])
+    create(:member, real_name: '山田太郎', projects: [project])
 
     sign_in login_user
     visit root_path

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -108,9 +108,9 @@ describe '3人組を探す機能' do
         find('.member-name', text: '山田太郎').click
       end
 
-      it '〜と同じプロジェクトのためという理由が表示がされること' do
+      it '〜と同じプロジェクトという理由が表示がされること' do
         within('.member-row', text: '鈴木一郎') do
-          expect(page).to have_content('山田太郎と同じプロジェクトです')
+          expect(page).to have_content('山田太郎と同じプロジェクト')
         end
       end
 
@@ -131,14 +131,14 @@ describe '3人組を探す機能' do
       end
 
       context 'ランチに行ったクウォーターと同じ期間の場合' do
-        it '〜と行ったことがあるという理由が表示がされること' do
+        it '〜とランチ済みという理由が表示がされること' do
           find('.member-name', text: '鈴木一郎').click
 
           within('.member-row', text: '鈴木二郎') do
-            expect(page).to have_content('鈴木一郎と行ったことがあります')
+            expect(page).to have_content('鈴木一郎とランチ済み')
           end
           within('.member-row', text: '鈴木三郎') do
-            expect(page).to have_content('鈴木一郎と行ったことがあります')
+            expect(page).to have_content('鈴木一郎とランチ済み')
           end
         end
 
@@ -163,14 +163,14 @@ describe '3人組を探す機能' do
           visit root_path
         end
 
-        it '〜と行ったことがあるという理由が表示がないこと' do
+        it '〜とランチ済みという理由が表示がないこと' do
           find('.member-name', text: '鈴木一郎').click
 
           within('.member-row', text: '鈴木二郎') do
-            expect(page).to_not have_content('鈴木一郎と行ったことがあります')
+            expect(page).to_not have_content('鈴木一郎とランチ済み')
           end
           within('.member-row', text: '鈴木三郎') do
-            expect(page).to_not have_content('鈴木一郎と行ったことがあります')
+            expect(page).to_not have_content('鈴木一郎とランチ済み')
           end
         end
       end

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -97,11 +97,10 @@ describe '3人組を探す機能' do
   end
 
   describe 'メンバーを選択する' do
-    it '名前をクリックすると枠に移動するか' do
+    it '名前をクリックすると枠に名前が移動すること' do
       find('.member-name', text: '山田太郎').click
 
       expect(first('.member-form').value).to eq '山田太郎'
-      expect(find('#members-list')).to_not have_content('山田太郎')
     end
 
     context '同じプロジェクトに所属するメンバー同士の組み合わせの場合' do

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -105,10 +105,22 @@ describe '3人組を探す機能' do
     end
 
     context '同じプロジェクトに所属するメンバー同士の組み合わせの場合' do
-      it 'メンバーの表示が消えて選択できない' do
+      before do
         find('.member-name', text: '山田太郎').click
+      end
 
-        expect(find('#members-list')).to_not have_content('鈴木一郎')
+      it '〜と同じプロジェクトのためという理由が表示がされること' do
+        within('.member-row', text: '鈴木一郎') do
+          expect(page).to have_content('山田太郎と同じプロジェクトです')
+        end
+      end
+
+      it 'クリックしても名前がフォームに移動しないこと' do
+        find('.member-row', text: '鈴木一郎').click
+
+        within('.lunch-form') do
+          expect(page).to_not have_content('鈴木一郎')
+        end
       end
     end
 

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -132,11 +132,29 @@ describe '3人組を探す機能' do
       end
 
       context 'ランチに行ったクウォーターと同じ期間の場合' do
-        it 'すでにランチに行ったメンバーの表示が消えること' do
+        it '〜と行ったことがあるという理由が表示がされること' do
           find('.member-name', text: '鈴木一郎').click
 
-          expect(find('#members-list')).to_not have_content('鈴木二郎')
-          expect(find('#members-list')).to_not have_content('鈴木三郎')
+          within('.member-row', text: '鈴木二郎') do
+            expect(page).to have_content('鈴木一郎と行ったことがあります')
+          end
+          within('.member-row', text: '鈴木三郎') do
+            expect(page).to have_content('鈴木一郎と行ったことがあります')
+          end
+        end
+
+        it 'クリックしても名前がフォームに移動しないこと' do
+          find('.member-row', text: '鈴木二郎').click
+
+          within('.lunch-form') do
+            expect(page).to_not have_content('鈴木二郎')
+          end
+
+          find('.member-row', text: '鈴木三郎').click
+
+          within('.lunch-form') do
+            expect(page).to_not have_content('鈴木三郎')
+          end
         end
       end
 
@@ -146,11 +164,15 @@ describe '3人組を探す機能' do
           visit root_path
         end
 
-        it 'すでにランチに行ったメンバーが表示があること' do
+        it '〜と行ったことがあるという理由が表示がないこと' do
           find('.member-name', text: '鈴木一郎').click
 
-          expect(find('#members-list')).to have_content('鈴木二郎')
-          expect(find('#members-list')).to have_content('鈴木三郎')
+          within('.member-row', text: '鈴木二郎') do
+            expect(page).to_not have_content('鈴木一郎と行ったことがあります')
+          end
+          within('.member-row', text: '鈴木三郎') do
+            expect(page).to_not have_content('鈴木一郎と行ったことがあります')
+          end
         end
       end
     end

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'メンバー管理機能', type: :system do
   before do
     create(:project)
-    create(:member)
+    create(:member, hundle_name: 'taro', real_name: '山田太郎')
     sign_in create(:user)
     visit root_path
     click_link 'メンバー'


### PR DESCRIPTION
## Issue
close #41 

## 内容
- ランチに行けない理由表示するようにした

### ランチに行けない理由表示するようにした
ランチ登録画面でメンバーをクリックすると、いままではクリックされたメンバーとランチに行けないメンバーは非表示にしていたが、なぜ非表示になったのかがわからないとユーザーは不安になる。

そのため、「〜と同じプロジェクト」「〜とランチ済み」という表示をランチに行けないメンバーにつけるようにした。

〜の部分にはクリックされ、フォームに移動するメンバーの名前が自動で入る。
それに合わせてランチに行けないメンバーは非表示にするのではなく、表示したままにして背景を灰色にして選択できるメンバーと区別させた。
選択したメンバーの複数の人と同じプロジェクトやランチ済みのメンバーは、カンマで区切りで複数の人を〜に入れて理由表示するようにした。
同じプロジェクトとランチ済みの両方の理由がある行には両方を改行を入れて表示させた。

実装については`app/assets/javascripts/lunch.js`で理由表示の処理を書いた。

理由が表示されることを確認するテストを書いた。

[![Image from Gyazo](https://i.gyazo.com/c63ac4cbe03c54d1fdf240f06f1f3e8e.gif)](https://gyazo.com/c63ac4cbe03c54d1fdf240f06f1f3e8e)

<!--
なぜそれが必要か,
どのような変更をしたか,
確かめる手順または画像や動画,
など
-->

## 備考
<!--
このプルリクエストに関連しているが、このプルリクエストでは対応しないこと,
マージ先のブランチへマージする他のプルリクエストの順番,
など
-->
