### PR TITLE
退職したメンバーを退職済みの状態にする機能

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -36,7 +36,7 @@ class LunchesController < ApplicationController
   private
 
   def set_variables_for_new_lunch_view
-    @members = Member.includes(:projects).where(retired: false)
+    @members = Member.includes(:projects).where(retired: false).order(:created_at)
     gon.lunch_trios = Quarter.current_quarter.lunches.includes(:members).map(&:members)
     gon.login_member = Member.find_by(email: current_user.email)
   end

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -36,7 +36,7 @@ class LunchesController < ApplicationController
   private
 
   def set_variables_for_new_lunch_view
-    @members = Member.includes(:projects)
+    @members = Member.includes(:projects).where(retired: false)
     gon.lunch_trios = Quarter.current_quarter.lunches.includes(:members).map(&:members)
     gon.login_member = Member.find_by(email: current_user.email)
   end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -2,7 +2,7 @@ class MembersController < ApplicationController
   before_action :set_member, only: [:edit, :update, :destroy]
 
   def index
-    @members = Member.includes(:projects)
+    @members = Member.includes(:projects).order(:created_at)
   end
 
   def new

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -23,14 +23,7 @@ class MembersController < ApplicationController
   end
 
   def update
-    updated_member_params =
-      if member_params[:retired] == '1'
-        member_params.merge(project_ids: [])
-      else
-        member_params
-      end
-
-    if @member.update(updated_member_params)
+    if @member.update(member_params)
       redirect_to members_url, notice: t('dictionary.message.update.complete', resource_name: @member.real_name)
     else
       render :edit

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -41,6 +41,6 @@ class MembersController < ApplicationController
     end
 
     def member_params
-      params.require(:member).permit(:hundle_name, :real_name, project_ids: [])
+      params.require(:member).permit(:hundle_name, :real_name, :retired, project_ids: [])
     end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -23,7 +23,14 @@ class MembersController < ApplicationController
   end
 
   def update
-    if @member.update(member_params)
+    updated_member_params =
+      if member_params[:retired] == '1'
+        member_params.merge(project_ids: [])
+      else
+        member_params
+      end
+
+    if @member.update(updated_member_params)
       redirect_to members_url, notice: t('dictionary.message.update.complete', resource_name: @member.real_name)
     else
       render :edit

--- a/app/views/members/_form.html.slim
+++ b/app/views/members/_form.html.slim
@@ -11,10 +11,11 @@
   .field.input-field
     = f.label :real_name, class: form_active(f.object.real_name)
     = f.text_field :real_name
-  .field
-    = f.label :retired do
-      = f.check_box :retired, class: 'filled-in'
-      span 退職済み
+  - if @member.persisted?
+    .field
+      = f.label :retired do
+        = f.check_box :retired, class: 'filled-in'
+        span 退職済み
   .field
     = f.label :project_ids, 'プロジェクト'
     = f.collection_select :project_ids, Project.all, :id, :name, {} ,{multiple: true, class: 'js-searchable'}

--- a/app/views/members/_form.html.slim
+++ b/app/views/members/_form.html.slim
@@ -12,6 +12,10 @@
     = f.label :real_name, class: form_active(f.object.real_name)
     = f.text_field :real_name
   .field
+    = f.label :retired do
+      = f.check_box :retired, class: 'filled-in'
+      span 退職済み
+  .field
     = f.label :project_ids, 'プロジェクト'
     = f.collection_select :project_ids, Project.all, :id, :name, {} ,{multiple: true, class: 'js-searchable'}
   .input-field

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -6,6 +6,7 @@ h3 メンバー
 table
   thead
     tr
+      th
       th = Member.human_attribute_name(:hundle_name)
       th = Member.human_attribute_name(:real_name)
       th = Member.human_attribute_name(:projects)
@@ -14,6 +15,9 @@ table
   tbody
     - @members.each do |member|
       tr
+        td
+          - if member.retired
+            span class='new badge grey lighten-1' data-badge-caption='退職済み'
         td = member.hundle_name
         td = member.real_name
         td = project_list(member)

--- a/db/migrate/20190911075805_add_retired_to_members.rb
+++ b/db/migrate/20190911075805_add_retired_to_members.rb
@@ -1,0 +1,5 @@
+class AddRetiredToMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :members, :retired, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20190913012432_add_index_to_retired_column.rb
+++ b/db/migrate/20190913012432_add_index_to_retired_column.rb
@@ -1,0 +1,5 @@
+class AddIndexToRetiredColumn < ActiveRecord::Migration[5.2]
+  def change
+    add_index :members, :retired
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_09_015506) do
+ActiveRecord::Schema.define(version: 2019_09_11_075805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2019_09_09_015506) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "email"
+    t.boolean "retired", default: false, null: false
     t.index ["email"], name: "index_members_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_11_075805) do
+ActiveRecord::Schema.define(version: 2019_09_13_012432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2019_09_11_075805) do
     t.string "email"
     t.boolean "retired", default: false, null: false
     t.index ["email"], name: "index_members_on_email", unique: true
+    t.index ["retired"], name: "index_members_on_retired"
   end
 
   create_table "projects", force: :cascade do |t|

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -56,6 +56,35 @@ describe 'メンバー管理機能', type: :system do
     end
   end
 
+  describe 'メンバーを退職済みにする機能' do
+    before do
+      create(:member, real_name: '退職太郎')
+
+      visit members_path
+      within('tr', text: '退職太郎') do
+        click_on 'edit'
+      end
+
+      # 退職済みをチェックする
+      find('span', text: '退職済み').click
+
+      click_on('更新する')
+    end
+
+    it '退職メンバーに退職済みのラベルが表示されること' do
+      within('tr', text: '退職太郎') do
+        expect(find('span')['data-badge-caption']).to eq '退職済み'
+      end
+    end
+
+    it '選択リストには退職メンバーの名前が無いこと' do
+      visit root_path
+      within('#members-list') do
+        expect(page).to_not have_content '退職太郎'
+      end
+    end
+  end
+
   describe '削除機能' do
     it '削除できるか' do
       find('.delete-btn').click


### PR DESCRIPTION
## Issue
close #39 

## 内容
- メンバーを退職済みの状態にできるようにした

### メンバーを退職済みの状態にできるようにした
退職したメンバーはランチに行くメンバーとして選べないようにしたいので、メンバーを退職済みの状態にするようにした。

メンバーの編集から退職済みにできるようにした。編集の操作はどのユーザーからもできる。materializeのcheckboxを使った。　https://materializecss.com/checkboxes.html

退職済みの状態がわかるように、メンバーの一覧ページで退職メンバーの一番左の列に「退職済み」の表示するようにした。
表示にはmaterializeのbudgeを使った。 https://materializecss.com/badges.html

退職済みのメンバーはランチに行くページのメンバー選択には出ないようにした。

[![Image from Gyazo](https://i.gyazo.com/9502147e8de0e5e59b2298f2c220bbb8.gif)](https://gyazo.com/9502147e8de0e5e59b2298f2c220bbb8)
<!--
なぜそれが必要か,
どのような変更をしたか,
確かめる手順または画像や動画,
など
-->

## 備考
<!--
このプルリクエストに関連しているが、このプルリクエストでは対応しないこと,
マージ先のブランチへマージする他のプルリクエストの順番,
など
-->
