### PR TITLE
既存のDBの日付とメンバーが重複したランチ履歴を削除して、以降重複したランチ履歴が作られないようにする

### DIFF
--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -1,6 +1,6 @@
 class LunchesController < ApplicationController
   def index
-    @quarters = Quarter.includes(lunches: [:lunches_members, :members, :created_by]).order("quarters.start_date" ,"lunches.date desc", "members.created_at")
+    @quarters = Quarter.includes(lunches: [:lunches_members, :members, :created_by]).order("quarters.start_date", "lunches.date desc", "members.created_at")
   end
 
   def new

--- a/app/controllers/lunches_controller.rb
+++ b/app/controllers/lunches_controller.rb
@@ -1,6 +1,6 @@
 class LunchesController < ApplicationController
   def index
-    @quarters = Quarter.includes(lunches: [:lunches_members, :members, :created_by]).order("quarters.start_date" ,"lunches.date desc")
+    @quarters = Quarter.includes(lunches: [:lunches_members, :members, :created_by]).order("quarters.start_date" ,"lunches.date desc", "members.created_at")
   end
 
   def new

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -25,7 +25,7 @@ class Lunch < ApplicationRecord
     lunches_in_same_quarter.each do |lunch|
       lunched_members = lunch.members & self.members
       if lunched_members.size >= 2
-        errors.add(:members, "#{lunched_members.map(&:real_name).join(',')}は#{lunch.date}にランチ済みです")
+        errors.add(:went_to_lunch_in_same_quarter_and_members, "#{lunched_members.map(&:real_name).join(',')}は#{lunch.date}にランチ済みです")
       end
     end
   end

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -19,10 +19,10 @@ class Lunch < ApplicationRecord
     errors.add(:members, "#{BENEFITS_AVAILABLE_MEMBERS_COUNT}人のメンバーを入力してください")
   end
 
-  # 現在のクォーター内で同じメンバーの組み合わせでランチに行ってないことを検証
+  # 同じクォーター内で同じメンバーの組み合わせでランチに行ってないことを検証
   def must_has_unique_trio_in_current_quarter
-    lunches_in_current_quarter = Quarter.current_quarter.lunches.includes(:members)
-    lunches_in_current_quarter.each do |lunch|
+    lunches_in_same_quarter = Lunch.includes(:members).where(quarter: quarter)
+    lunches_in_same_quarter.each do |lunch|
       lunched_members = lunch.members & self.members
       if lunched_members.size >= 2
         errors.add(:members, "#{lunched_members.map(&:real_name).join(',')}は#{lunch.date}にランチ済みです")

--- a/app/models/lunch.rb
+++ b/app/models/lunch.rb
@@ -3,7 +3,7 @@ class Lunch < ApplicationRecord
   belongs_to :quarter
   has_and_belongs_to_many :members
   validate :must_have_benefits_available_count_members
-  validate :must_has_unique_trio_in_current_quarter
+  validate :must_go_to_lunch_with_members_who_did_not_go_together_during_same_quarter
 
   BENEFITS_AVAILABLE_MEMBERS_COUNT = 3
 
@@ -20,12 +20,12 @@ class Lunch < ApplicationRecord
   end
 
   # 同じクォーター内で同じメンバーの組み合わせでランチに行ってないことを検証
-  def must_has_unique_trio_in_current_quarter
+  def must_go_to_lunch_with_members_who_did_not_go_together_during_same_quarter
     lunches_in_same_quarter = Lunch.includes(:members).where(quarter: quarter)
     lunches_in_same_quarter.each do |lunch|
-      lunched_members = lunch.members & self.members
-      if lunched_members.size >= 2
-        errors.add(:went_to_lunch_in_same_quarter_and_members, "#{lunched_members.map(&:real_name).join(',')}は#{lunch.date}にランチ済みです")
+      members_who_went_to_lunch_together = lunch.members & self.members
+      if members_who_went_to_lunch_together.size >= 2
+        errors.add(:went_to_lunch_with_same_members, "#{members_who_went_to_lunch_together.map(&:real_name).join(',')}は#{lunch.date}にランチ済みです")
       end
     end
   end

--- a/lib/tasks/delete_db_data.rake
+++ b/lib/tasks/delete_db_data.rake
@@ -1,0 +1,25 @@
+namespace :delete_db_data do
+  desc '同じクォーターの中で同じ日に同じメンバーと行ったランチ履歴を削除する'
+  task delete_duplicate_lunch: :environment do
+    puts '同じクォーターの中で同じ日に同じメンバーと行ったランチ履歴を削除します'
+    quarter = Quarter.includes(lunches: [:lunches_members, :members]).order("quarters.start_date" ,"lunches.date", "lunches.created_at", "members.created_at")
+    quarter.each do |quarter|
+      finish_iterate_lunches = []
+      quarter.lunches.each do |lunch|
+        finish_iterate_lunches.each do |finish_iterate_lunch|
+          next unless (finish_iterate_lunch.date == lunch.date) && (finish_iterate_lunch.members == lunch.members)
+          puts <<~EOS
+          #{finish_iterate_lunch.inspect} #{finish_iterate_lunch.members.map(&:real_name).join(',')}のランチと
+          #{lunch.inspect} #{lunch.members.map(&:real_name).join(',')}のランチが重複してます。
+          #{lunch.inspect} #{lunch.members.map(&:real_name).join(',')}のランチを削除します
+          EOS
+
+          lunch.delete
+          puts '削除しました'
+          break
+        end
+        finish_iterate_lunches << lunch if lunch.persisted?
+      end
+    end
+  end
+end

--- a/spec/model/lunch_spec.rb
+++ b/spec/model/lunch_spec.rb
@@ -7,4 +7,20 @@ describe Lunch do
     lunch = build(:lunch, members: [member1, member2])
     expect(lunch).to_not be_valid
   end
+
+  it '同じクォーターの中で同じ組み合わせがあると、有効ではないこと' do
+    members = [
+      create(:member, real_name: '鈴木一郎'),
+      create(:member, real_name: '鈴木二郎'),
+      create(:member, real_name: '鈴木三郎')
+    ]
+
+    login_user = create(:user)
+    create_lunch(members, login_user, date: Date.new(2019,9,15))
+
+    lunch = build_lunch(members, login_user, date: Date.new(2019,9,16))
+
+    expect(lunch).to_not be_valid
+    expect(lunch.errors.messages[:went_to_lunch_in_same_quarter_and_members]).to eq ['鈴木一郎,鈴木二郎,鈴木三郎は2019-09-15にランチ済みです']
+  end
 end

--- a/spec/model/lunch_spec.rb
+++ b/spec/model/lunch_spec.rb
@@ -21,6 +21,6 @@ describe Lunch do
     lunch = build_lunch(members, login_user, date: Date.new(2019,9,16))
 
     expect(lunch).to_not be_valid
-    expect(lunch.errors.messages[:went_to_lunch_in_same_quarter_and_members]).to eq ['鈴木一郎,鈴木二郎,鈴木三郎は2019-09-15にランチ済みです']
+    expect(lunch.errors.messages[:went_to_lunch_with_same_members]).to eq ['鈴木一郎,鈴木二郎,鈴木三郎は2019-09-15にランチ済みです']
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -61,4 +61,5 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include FactoryBot::Syntax::Methods
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include LunchHelpers
 end

--- a/spec/support/helpers/lunch_helpers.rb
+++ b/spec/support/helpers/lunch_helpers.rb
@@ -1,4 +1,9 @@
 module LunchHelpers
+  def build_lunch(members, user, date: Date.today)
+    quarter = Quarter.find_or_create_quarter(date)
+    build(:lunch, members: members, date: date, quarter: quarter, created_by: user)
+  end
+
   def create_lunch(members, user, date: Date.today)
     quarter = Quarter.find_or_create_quarter(date)
     create(:lunch, members: members, date: date, quarter: quarter, created_by: user)

--- a/spec/support/helpers/lunch_helpers.rb
+++ b/spec/support/helpers/lunch_helpers.rb
@@ -1,0 +1,6 @@
+module LunchHelpers
+  def create_lunch(members, user, date: Date.today)
+    quarter = Quarter.find_or_create_quarter(date)
+    create(:lunch, members: members, date: date, quarter: quarter, created_by: user)
+  end
+end

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -27,12 +27,12 @@ describe 'ランチ履歴の表示機能' do
   it 'クオーターごとに履歴が表示される' do
     visit lunches_path
 
-    expect(page).to have_content('2019-09-15')
-    expect(page).to have_content('2019-09-16')
+    expect(page).to have_content('2019-09-15 鈴木一郎,鈴木二郎,鈴木三郎')
+    expect(page).to have_content('2019-09-16 鈴木一郎,鈴木四郎,鈴木五郎')
 
     click_on('40期-2Q')
 
-    expect(page).to have_content('2019-12-15')
+    expect(page).to have_content('2019-12-15 鈴木一郎,鈴木二郎,鈴木三郎')
   end
 end
 

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -7,15 +7,18 @@ end
 
 describe 'ランチ履歴の表示機能' do
   before do
-    members = [
-      create(:member, real_name: '鈴木一郎'),
-      create(:member, real_name: '鈴木二郎'),
-      create(:member, real_name: '鈴木三郎')
-    ]
+    member1 = create(:member, real_name: '鈴木一郎')
+    member2 = create(:member, real_name: '鈴木二郎')
+    member3 = create(:member, real_name: '鈴木三郎')
+    member4 = create(:member, real_name: '鈴木四郎')
+    member5 = create(:member, real_name: '鈴木五郎')
+    trio1 = [member1, member2, member3]
+    trio2 = [member1, member4, member5]
+
     login_user = create(:user)
-    create_lunch(members, login_user, date: Date.new(2019,9,15))
-    create_lunch(members, login_user, date: Date.new(2019,9,16))
-    create_lunch(members, login_user, date: Date.new(2019,12,15))
+    create_lunch(trio1, login_user, date: Date.new(2019,9,15))
+    create_lunch(trio2, login_user, date: Date.new(2019,9,16))
+    create_lunch(trio1, login_user, date: Date.new(2019,12,15))
 
     sign_in login_user
     visit root_path

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -1,10 +1,5 @@
 require 'rails_helper'
 
-def create_lunch(members, user, date: Date.today)
-  quarter = Quarter.find_or_create_quarter(date)
-  create(:lunch, members: members, date: date, quarter: quarter, created_by: user)
-end
-
 describe 'ランチ履歴の表示機能' do
   before do
     member1 = create(:member, real_name: '鈴木一郎')


### PR DESCRIPTION
## Issue
close #48 

## 内容
- 同じクォーターの中でメンバーの組み合わせが重複したランチ履歴が登録できないようにした
- DBのランチ履歴の中で同じ日で同じメンバー同士のランチ履歴がある場合、その重複した履歴を削除するRakeタスクを作成

### 同じクォーターの中でメンバーの組み合わせが重複したランチ履歴が登録できないようにした

同じタイミングで２人のユーザーがランチ登録ページを開いている場合、
片方のユーザーがランチを登録しても、
もう一方のユーザーのメンバー選択リストは更新しなければ変わらないので、同じメンバーの組み合わせのランチを登録できてしまっていた。

それを防ぐために、現在のクォーター内で同じメンバーの組み合わせでランチに行ってないことを検証するvalidationを作った。

### DBのランチデータの中で同じクォーターの中で同じ日で同じメンバー同士のランチ履歴がある場合、重複したデータを削除するRakeタスクを作成

複数の人が同じ履歴（同じ日、同じメンバーが行ったランチ履歴）を登録してしまったデータが本番環境にあるので、その一方を削除することにした。

履歴の中で同じ日で同じメンバーのランチ履歴を見つけて、後に作られたRakeタスクを作って削除するようにした。

まず、本番環境のDBデータをdumpしてローカルのDBにresore。
ローカルでRakeタスクを実行して削除されてほしいデータが削除されたことを確かめた。

このPRがマージされたら、本番環境で実行する。
<!--
なぜそれが必要か,
どのような変更をしたか,
確かめる手順または画像や動画,
など
-->

## 備考
<!--
このプルリクエストに関連しているが、このプルリクエストでは対応しないこと,
マージ先のブランチへマージする他のプルリクエストの順番,
など
-->
