### PR TITLE
削除ボタンを移動して見た目を変更

### DIFF
--- a/app/views/lunches/index.html.slim
+++ b/app/views/lunches/index.html.slim
@@ -22,4 +22,4 @@ ul.tabs
             td = lunch.members.pluck(:real_name).join(',')
             td
               - if lunch.created_by == current_user
-                = link_to mi.delete, lunch, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: lunch.label_with_date_and_member_names) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'
+                = link_to '削除する', lunch, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: lunch.label_with_date_and_member_names) }, method: :delete, class: 'btn-small red delete-btn'

--- a/app/views/members/_form.html.slim
+++ b/app/views/members/_form.html.slim
@@ -22,4 +22,4 @@
   .input-field
     .actions = f.submit id: 'submit-btn', class: 'btn text-white'
 - if @member.persisted?
-  = link_to '削除する' , @member, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: @member.real_name) }, method: :delete, class: 'btn delete-btn'
+  = link_to '削除する' , @member, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: @member.real_name) }, method: :delete, class: 'btn red delete-btn'

--- a/app/views/members/_form.html.slim
+++ b/app/views/members/_form.html.slim
@@ -21,3 +21,5 @@
     = f.collection_select :project_ids, Project.all, :id, :name, {} ,{multiple: true, class: 'js-searchable'}
   .input-field
     .actions = f.submit id: 'submit-btn', class: 'btn text-white'
+- if @member.persisted?
+  = link_to '削除する' , @member, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: @member.real_name) }, method: :delete, class: 'btn delete-btn'

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -23,5 +23,3 @@ table
         td = project_list(member)
         td
           = link_to mi.edit, edit_member_path(member), class: 'btn-small z-depth-0 edit-btn'
-          |  
-          = link_to mi.delete , member, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: member.real_name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -10,3 +10,5 @@
     = f.text_field :name
   .input-field
     .actions = f.submit id: 'submit-btn', class: 'btn text-white'
+- if @project.persisted?
+  = link_to '削除する', @project, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: @project.name) }, method: :delete, class: 'btn red delete-btn'

--- a/app/views/projects/index.html.slim
+++ b/app/views/projects/index.html.slim
@@ -16,5 +16,3 @@ table
         td = project.name
         td
           = link_to mi.edit, edit_project_path(project), class: 'btn-small z-depth-0 edit-btn'
-          |  
-          = link_to mi.delete, project, data: { confirm: t('dictionary.message.destroy.confirm', resource_name: project.name) }, method: :delete, class: 'btn-small z-depth-0 delete-btn'

--- a/spec/system/lunch_spec.rb
+++ b/spec/system/lunch_spec.rb
@@ -52,7 +52,7 @@ describe 'ランチ履歴を登録したユーザーだけその履歴を削除�
 
   it '自分の登録した履歴は削除ボタンから削除できること' do
     within('tr', text: '鈴木一郎,鈴木二郎,鈴木三郎') do
-      click_on('delete')
+      click_on('削除する')
     end
     page.driver.browser.switch_to.alert.accept
 
@@ -67,7 +67,7 @@ describe 'ランチ履歴を登録したユーザーだけその履歴を削除�
     visit lunches_path
 
     within('tr', text: '鈴木一郎,鈴木二郎,鈴木三郎') do
-      expect(page).to_not have_content('delete')
+      expect(page).to_not have_content('削除する')
     end
   end
 end

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -87,8 +87,10 @@ describe 'メンバー管理機能', type: :system do
 
   describe '削除機能' do
     it '削除できるか' do
-      find('.delete-btn').click
+      find('.edit-btn').click
+      click_on('削除する')
       page.driver.browser.switch_to.alert.accept
+
       expect(page).to have_content '山田太郎を削除しました'
     end
   end

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -44,8 +44,10 @@ describe 'プロジェクト管理機能' do
 
   describe '削除機能' do
     it '削除できるか' do
-      find('.delete-btn').click
+      find('.edit-btn').click
+      click_on('削除する')
       page.driver.browser.switch_to.alert.accept
+
       expect(page).to have_content 'eiwakunを削除しました'
     end
   end


### PR DESCRIPTION
削除ボタンが押しやすいところにあったため、編集画面へ移動させた。
削除ということがわかりやすいようにボタンを赤色に変更。
